### PR TITLE
[Flight] Let encodeFormAction reuse the default encoding

### DIFF
--- a/packages/react-client/src/ReactFlightReplyClient.js
+++ b/packages/react-client/src/ReactFlightReplyClient.js
@@ -59,6 +59,7 @@ export type CallServerCallback = <A, T>(id: any, args: A) => Promise<T>;
 export type EncodeFormActionCallback = <A>(
   id: any,
   args: Promise<A>,
+  encodeDefault: () => ReactCustomFormAction,
 ) => ReactCustomFormAction;
 
 export type ServerReferenceId = any;
@@ -1029,7 +1030,9 @@ function customEncodeFormAction(
   if (boundPromise === null) {
     boundPromise = Promise.resolve([]);
   }
-  return encodeFormAction(referenceClosure.id, boundPromise);
+  return encodeFormAction(referenceClosure.id, boundPromise, () =>
+    defaultEncodeFormAction.call(reference, identifierPrefix),
+  );
 }
 
 function isSignatureEqual(

--- a/packages/react-server-dom-esm/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-esm/src/client/ReactFlightDOMClientNode.js
@@ -49,6 +49,7 @@ export function createServerReference<A: Iterable<any>, T>(
 type EncodeFormActionCallback = <A>(
   id: any,
   args: Promise<A>,
+  encodeDefault: () => ReactCustomFormAction,
 ) => ReactCustomFormAction;
 
 export type Options = {

--- a/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientEdge.js
@@ -71,6 +71,7 @@ export function createServerReference<A: Iterable<any>, T>(
 type EncodeFormActionCallback = <A>(
   id: any,
   args: Promise<A>,
+  encodeDefault: () => ReactCustomFormAction,
 ) => ReactCustomFormAction;
 
 export type Options = {

--- a/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientNode.js
@@ -45,6 +45,7 @@ function noServerCall() {
 type EncodeFormActionCallback = <A>(
   id: any,
   args: Promise<A>,
+  encodeDefault: () => ReactCustomFormAction,
 ) => ReactCustomFormAction;
 
 export type Options = {

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientEdge.js
@@ -69,6 +69,7 @@ export function createServerReference<A: Iterable<any>, T>(
 type EncodeFormActionCallback = <A>(
   id: any,
   args: Promise<A>,
+  encodeDefault: () => ReactCustomFormAction,
 ) => ReactCustomFormAction;
 
 export type Options = {

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
@@ -52,6 +52,7 @@ function noServerCall() {
 type EncodeFormActionCallback = <A>(
   id: any,
   args: Promise<A>,
+  encodeDefault: () => ReactCustomFormAction,
 ) => ReactCustomFormAction;
 
 export type Options = {

--- a/packages/react-server-dom-unbundled/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-unbundled/src/client/ReactFlightDOMClientEdge.js
@@ -69,6 +69,7 @@ export function createServerReference<A: Iterable<any>, T>(
 type EncodeFormActionCallback = <A>(
   id: any,
   args: Promise<A>,
+  encodeDefault: () => ReactCustomFormAction,
 ) => ReactCustomFormAction;
 
 export type Options = {

--- a/packages/react-server-dom-unbundled/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-unbundled/src/client/ReactFlightDOMClientNode.js
@@ -52,6 +52,7 @@ function noServerCall() {
 type EncodeFormActionCallback = <A>(
   id: any,
   args: Promise<A>,
+  encodeDefault: () => ReactCustomFormAction,
 ) => ReactCustomFormAction;
 
 export type Options = {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMForm-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMForm-test.js
@@ -243,6 +243,48 @@ describe('ReactFlightDOMForm', () => {
     expect(foo).toBe('barobject');
   });
 
+  it('can customize a form action while reusing the default encoding', async () => {
+    let foo = null;
+
+    const serverAction = serverExports(function action(bound, formData) {
+      foo = formData.get('foo') + bound.complex;
+      return 'hello';
+    });
+    function App() {
+      return (
+        <form action={serverAction.bind(null, {complex: 'object'})}>
+          <input type="text" name="foo" defaultValue="bar" />
+        </form>
+      );
+    }
+
+    const rscStream = ReactServerDOMServer.renderToReadableStream(<App />);
+    const response = ReactServerDOMClient.createFromReadableStream(rscStream, {
+      serverConsumerManifest: {
+        moduleMap: null,
+        moduleLoading: null,
+      },
+      encodeFormAction(id, args, encodeDefault) {
+        expect(id).toBe(serverAction.$$id);
+        expect(typeof args.then).toBe('function');
+        return {
+          ...encodeDefault(),
+          action: '/custom-action',
+        };
+      },
+    });
+    const ssrStream = await ReactDOMServer.renderToReadableStream(response);
+    await readIntoContainer(ssrStream);
+
+    const form = container.firstChild;
+    expect(form.action).toBe('http://localhost/custom-action');
+
+    const {returnValue} = await submit(form);
+
+    expect(returnValue).toBe('hello');
+    expect(foo).toBe('barobject');
+  });
+
   it('can submit a multiple complex closure server action without hydrating it', async () => {
     let foo = null;
 

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientEdge.js
@@ -69,6 +69,7 @@ export function createServerReference<A: Iterable<any>, T>(
 type EncodeFormActionCallback = <A>(
   id: any,
   args: Promise<A>,
+  encodeDefault: () => ReactCustomFormAction,
 ) => ReactCustomFormAction;
 
 export type Options = {

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
@@ -52,6 +52,7 @@ function noServerCall() {
 type EncodeFormActionCallback = <A>(
   id: any,
   args: Promise<A>,
+  encodeDefault: () => ReactCustomFormAction,
 ) => ReactCustomFormAction;
 
 export type Options = {


### PR DESCRIPTION
## Summary

Fixes #37044.

`encodeFormAction` fully replaces React's default form action encoding, so a framework can't call the default encoder and change only one field (e.g. adding a query marker to the action URL while keeping the default encoding so `decodeAction` still works).

This passes a bound default encoder as a third argument to the callback:

```ts
encodeFormAction?: (
  id: string,
  args: Promise<unknown[]>,
  encodeDefault: () => ReactCustomFormAction,
) => ReactCustomFormAction;
```

A framework can now write:

```ts
const encodeFormAction = (id, args, encodeDefault) => ({
  ...encodeDefault(),
  action: currentUrl + '?my-marker=1',
});
```

React keeps control of caching, prefixing, and suspension (via `defaultEncodeFormAction`), while frameworks only override the fields they need.

## Changes

- `packages/react-client/src/ReactFlightReplyClient.js`: added the third parameter to `EncodeFormActionCallback` and wired `customEncodeFormAction` to pass a bound `() => defaultEncodeFormAction.call(reference, identifierPrefix)`.
- Mirrored the same type update in the local `EncodeFormActionCallback` declaration in every bundler client entry point (webpack, turbopack, parcel, unbundled Edge + Node variants, and esm's Node variant) so Flow stays consistent across all of them.
- Added a test in `ReactFlightDOMForm-test.js` covering a custom encoder that calls `encodeDefault()` and overrides the `action` field, asserting both the override and the default-derived encoding/round-trip still work.

Out of scope: the separate `useActionState` `permalink` interaction mentioned in the issue is a distinct, unconfirmed follow-on idea and isn't part of this change.

## Test plan
- [x] Added `ReactFlightDOMForm-test.js` test: custom encoder reusing `encodeDefault()` and overriding `action`
- [x] `node ./scripts/jest/jest-cli.js ReactFlightDOMForm-test --testPathPattern=react-server-dom-webpack` — 221/222 passing (the one failure is a pre-existing, unrelated timeout in `ReactFlightDOMEdge-test.js`, confirmed present on `main` without this change too)
- [x] `flow check` on `dom-node-webpack` and `dom-edge-webpack` configs — no errors