### PR TITLE
Pass debug stream value to startReadingFromStream on the debug channel

### DIFF
--- a/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientEdge.js
@@ -168,7 +168,12 @@ export function createFromReadableStream<T>(
         close(response);
       }
     };
-    startReadingFromStream(response, options.debugChannel.readable, handleDone);
+    startReadingFromStream(
+      response,
+      options.debugChannel.readable,
+      handleDone,
+      options.debugChannel.readable,
+    );
     startReadingFromStream(response, stream, handleDone, stream);
   } else {
     startReadingFromStream(
@@ -205,6 +210,7 @@ export function createFromFetch<T>(
           response,
           options.debugChannel.readable,
           handleDone,
+          options.debugChannel.readable,
         );
         startReadingFromStream(response, r.body as any, handleDone, r);
       } else {

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientEdge.js
@@ -170,7 +170,12 @@ function createFromReadableStream<T>(
         close(response);
       }
     };
-    startReadingFromStream(response, options.debugChannel.readable, handleDone);
+    startReadingFromStream(
+      response,
+      options.debugChannel.readable,
+      handleDone,
+      options.debugChannel.readable,
+    );
     startReadingFromStream(response, stream, handleDone, stream);
   } else {
     startReadingFromStream(
@@ -207,6 +212,7 @@ function createFromFetch<T>(
           response,
           options.debugChannel.readable,
           handleDone,
+          options.debugChannel.readable,
         );
         startReadingFromStream(response, r.body as any, handleDone, r);
       } else {

--- a/packages/react-server-dom-unbundled/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-unbundled/src/client/ReactFlightDOMClientEdge.js
@@ -170,7 +170,12 @@ function createFromReadableStream<T>(
         close(response);
       }
     };
-    startReadingFromStream(response, options.debugChannel.readable, handleDone);
+    startReadingFromStream(
+      response,
+      options.debugChannel.readable,
+      handleDone,
+      options.debugChannel.readable,
+    );
     startReadingFromStream(response, stream, handleDone, stream);
   } else {
     startReadingFromStream(
@@ -207,6 +212,7 @@ function createFromFetch<T>(
           response,
           options.debugChannel.readable,
           handleDone,
+          options.debugChannel.readable,
         );
         startReadingFromStream(response, r.body as any, handleDone, r);
       } else {

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientEdge.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientEdge.js
@@ -170,7 +170,12 @@ function createFromReadableStream<T>(
         close(response);
       }
     };
-    startReadingFromStream(response, options.debugChannel.readable, handleDone);
+    startReadingFromStream(
+      response,
+      options.debugChannel.readable,
+      handleDone,
+      options.debugChannel.readable,
+    );
     startReadingFromStream(response, stream, handleDone, stream);
   } else {
     startReadingFromStream(
@@ -207,6 +212,7 @@ function createFromFetch<T>(
           response,
           options.debugChannel.readable,
           handleDone,
+          options.debugChannel.readable,
         );
         startReadingFromStream(response, r.body as any, handleDone, r);
       } else {


### PR DESCRIPTION
## Summary

`startReadingFromStream` takes a `debugValue` argument that's used to construct the per-stream debug state (`createStreamState(response, debugValue)`), and to identify which stream a chunk came from when both a debug channel and the main content stream are being read concurrently.

In the Edge clients (webpack, turbopack, parcel, unbundled), the debug-channel branch of `createFromReadableStream` and `createFromFetch` calls `startReadingFromStream` for `options.debugChannel.readable` without passing a `debugValue` — while the main content stream call right next to it on the following line correctly passes one (`stream` / `r`). This leaves `debugValue` as `undefined` on the debug-channel read path, inconsistent with every other call site.

This passes `options.debugChannel.readable` itself as the `debugValue` for that call, matching the pattern used everywhere else in the same functions.

## Changes
- `packages/react-server-dom-webpack/src/client/ReactFlightDOMClientEdge.js`
- `packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientEdge.js`
- `packages/react-server-dom-parcel/src/client/ReactFlightDOMClientEdge.js`
- `packages/react-server-dom-unbundled/src/client/ReactFlightDOMClientEdge.js`

Each gets the same one-line addition at both call sites (`createFromReadableStream` and `createFromFetch`).

## Test plan
- [x] `node ./scripts/jest/jest-cli.js --testPathPattern="react-server-dom-webpack|react-server-dom-turbopack|react-server-dom-parcel|react-server-dom-unbundled" -t "debug"` — 20/20 passing
- [x] Full `ReactFlightDOMEdge-test.js` suite — 41/42 passing (the one failure is a pre-existing, unrelated timeout also present on `main` without this change)
- [x] `flow check` on `dom-edge-webpack` config — no errors