### PR TITLE
[DOM] Handle blur on Fragments below `Document`

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3232,8 +3232,11 @@ FragmentInstance.prototype.blur = function (this: FragmentInstanceType): void {
   const parentInstanceOrContainer = getInstanceFromHostFiber<
     Instance | Container,
   >(parentHostFiber);
-  // TODO: Handle parentInstanceOrContainer being a document
-  const activeElement = parentInstanceOrContainer.ownerDocument.activeElement;
+  // Instance is included in the Container type for DOM.
+  const ownerDocument = getOwnerDocumentFromRootContainer(
+    parentInstanceOrContainer,
+  );
+  const activeElement = ownerDocument.activeElement;
   if (
     activeElement === null ||
     !parentInstanceOrContainer.contains(activeElement)

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefsDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefsDocument-test.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails reactcore
+ * @jest-environment node
+ */
+
+'use strict';
+
+let JSDOM;
+let React;
+let ReactDOMClient;
+let act;
+let document;
+let Fragment;
+
+describe('FragmentRefs', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    JSDOM = require('jsdom');
+    React = require('react');
+    Fragment = React.Fragment;
+    ReactDOMClient = require('react-dom/client');
+    act = require('internal-test-utils').act;
+
+    const jsdom = new JSDOM.JSDOM('');
+    document = jsdom.window.document;
+    global.window = jsdom.window;
+    global.document = global.window.document;
+  });
+
+  describe('focus methods', () => {
+    describe('blur()', () => {
+      // @gate enableFragmentRefs
+      it('throws when the nearest host parent is a Document container', async () => {
+        const fragmentRef = React.createRef();
+        const root = ReactDOMClient.createRoot(document);
+
+        await act(() => {
+          root.render(
+            <Fragment ref={fragmentRef}>
+              <html>
+                <body>
+                  <a id="child-a" href="/">
+                    A
+                  </a>
+                </body>
+              </html>
+            </Fragment>,
+          );
+        });
+
+        await act(() => {
+          fragmentRef.current.focus();
+        });
+        expect(document.activeElement.id).toEqual('child-a');
+
+        // TODO: blur() should remove focus from the child. Currently the
+        // HostRoot fallback returns the Document container, whose
+        // `ownerDocument` is null, so reading `activeElement` from it throws.
+        expect(() => fragmentRef.current.blur()).toThrow();
+      });
+    });
+  });
+});

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefsDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefsDocument-test.js
@@ -58,10 +58,10 @@ describe('FragmentRefs', () => {
         });
         expect(document.activeElement.id).toEqual('child-a');
 
-        // TODO: blur() should remove focus from the child. Currently the
-        // HostRoot fallback returns the Document container, whose
-        // `ownerDocument` is null, so reading `activeElement` from it throws.
-        expect(() => fragmentRef.current.blur()).toThrow();
+        await act(() => {
+          fragmentRef.current.blur();
+        });
+        expect(document.activeElement).toEqual(document.body);
       });
     });
   });


### PR DESCRIPTION
When we `blur`, we check first if the active element is even within the Fragment to avoid having to traverse the whole subtree.

However, assuming `ownerDocument` returns a `Document` is incorrect for the cases where the `Node` is a `Document`. Then the `ownerDocument` is `null`. We need to handle that case to avoid `Cannot read properties of null (reading 'activeElement')`.