### PR TITLE
Fix hydration mismatch for <script> in <head> when using importMap

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3895,11 +3895,12 @@ export function canHydrateInstance(
             // This script is for a different src/type/crossOrigin. It may be a script resource
             // or it may just be a mistmatch
             if (
-              srcAttr &&
-              element.hasAttribute('async') &&
-              !element.hasAttribute('itemprop')
+              (srcAttr &&
+                element.hasAttribute('async') &&
+                !element.hasAttribute('itemprop')) ||
+              element.getAttribute('type') === 'importmap'
             ) {
-              // This is an async script resource
+              // This is an async script resource, or React's own injected import map
               break;
             }
           }

--- a/packages/react-dom/src/__tests__/ReactDOMFizzStatic-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStatic-test.js
@@ -409,4 +409,76 @@ describe('ReactDOMFizzStatic', () => {
     expect(errors).toEqual(['async']);
     expect(getVisibleChildren(container)).toEqual(undefined);
   });
+
+  // Regression test for https://github.com/facebook/react/issues/36169
+  // When prerendering with both importMap and bootstrapModules, React injects
+  // its own <script type="importmap"> into <head>. A user <script> in <head>
+  // must not be matched against that injected importmap script during
+  // hydration, otherwise it produces a spurious hydration mismatch.
+  it('should hydrate a <script> in <head> without a mismatch when an importMap script is injected', async () => {
+    const importMap = {
+      imports: {
+        foo: 'path/to/foo.js',
+      },
+    };
+
+    function App() {
+      return (
+        <html>
+          <head>
+            <script src="https://example.test/script.js" defer={true} />
+            <title>Hello</title>
+          </head>
+          <body>
+            <div id="root">hello world</div>
+          </body>
+        </html>
+      );
+    }
+
+    const result = await ReactDOMFizzStatic.prerenderToNodeStream(<App />, {
+      importMap,
+      bootstrapModules: ['init.js'],
+    });
+
+    // Read the full prerendered document, then hydrate it as a whole document so
+    // that the injected <script type="importmap"> in <head> participates in
+    // hydration (React resolves head as a singleton against the global document).
+    result.prelude.setEncoding('utf8');
+    const html = await new Promise((resolve, reject) => {
+      let content = '';
+      result.prelude.on('data', chunk => {
+        content += chunk;
+      });
+      result.prelude.on('end', () => resolve(content));
+      result.prelude.on('error', reject);
+    });
+
+    const doc = global.document;
+    const tempDom = new JSDOM(html);
+    doc.head.innerHTML = tempDom.window.document.head.innerHTML;
+    doc.body.innerHTML = tempDom.window.document.body.innerHTML;
+    // The render-blocking <link rel="expect"> is normally resolved by the Fizz
+    // runtime once the shell finishes streaming; we hydrate a static snapshot so
+    // remove it to let hydration proceed.
+    const expectLink = doc.querySelector('link[rel="expect"]');
+    if (expectLink) {
+      expectLink.remove();
+    }
+
+    const recoverableErrors = [];
+    global.requestAnimationFrame = global.window.requestAnimationFrame = cb =>
+      setTimeout(cb);
+    // Use the real (scheduler-flushing) act so hydration actually traverses.
+    const clientAct = require('internal-test-utils').act;
+    await clientAct(async () => {
+      ReactDOMClient.hydrateRoot(doc, <App />, {
+        onRecoverableError(error) {
+          recoverableErrors.push(error.message);
+        },
+      });
+    });
+
+    expect(recoverableErrors).toEqual([]);
+  });
 });


### PR DESCRIPTION
Fixes #36169.

When `prerenderToNodeStream` is called with the `importMap` option, React writes its own `<script type="importmap">` directly into `<head>`. On hydration, `canHydrateInstance`'s script-matching logic in `ReactFiberConfigDOM.js` walks the head's DOM children looking for a match for each script fiber, and it's supposed to skip past script tags it doesn't recognize as the one it's looking for. The skip condition only covered one shape though: an async script with a `src` (the typical 3rd-party analytics tag pattern). The injected importmap script has no `src` and isn't `async`, so it fell through and got accepted as the match for the app's own `<script>` in `<head>`, producing a hydration mismatch.

This adds a check for `type="importmap"` to the existing skip condition, the same way the `meta`/`link`/`style` cases right above it already recognize their own known resource shapes.

Repro (adapted from the issue, no `defer` needed to trigger it once there's an importmap script in head):

```js
const { prelude } = await prerenderToNodeStream(<App />, {
  bootstrapModules: ['./client.js'],
  importMap: { imports: { react: '...' } },
});
```

Verified this hangs together with @eps1lon's finding in the issue thread (script gets matched against `src={null} type="importmap"` instead of its own props).

Added a regression test to `ReactDOMFizzStatic-test.js` that prerenders with both `importMap` and `bootstrapModules` set and a `<script>` in `<head>`, then hydrates and asserts no recoverable errors. Confirmed it fails without the fix and passes with it. Also ran the full `ReactDOMFloat`, `ReactDOMHydrationDiff`, `ReactServerRenderingHydration`, `ReactDOMFizzShellHydration`, and `ReactDOMLegacyFloat` suites (207 tests) to check for regressions in the shared hydration-matching code — all pass.