### PR TITLE
[compiler] Fix crash on recursive named function expressions

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
@@ -40,6 +40,7 @@ import {
   ValueReason,
 } from '../HIR';
 import {
+  eachInstructionLValue,
   eachInstructionValueOperand,
   eachPatternItem,
   eachTerminalOperand,
@@ -118,6 +119,27 @@ export function inferMutationAliasingEffects(
       reason: new Set([ValueReason.Other]),
     });
     initialState.define(ref, value);
+  }
+
+  /**
+   * A named function expression may recursively reference its own name from
+   * within its body (`const f = function foo() { foo() }`). That self-reference
+   * is bound in the function's own scope, so it is neither a parameter nor a
+   * captured context variable and is never seeded above. Seed any such
+   * self-reference as a context value so that reads of the function's own name
+   * resolve, rather than tripping the "value kind not initialized" invariant.
+   */
+  for (const selfReference of findRecursiveSelfReferences(fn)) {
+    const value: InstructionValue = {
+      kind: 'ObjectExpression',
+      properties: [],
+      loc: selfReference.loc,
+    };
+    initialState.initialize(value, {
+      kind: ValueKind.Context,
+      reason: new Set([ValueReason.Other]),
+    });
+    initialState.define(selfReference, value);
   }
 
   const paramKind: AbstractValue = isFunctionExpression
@@ -221,6 +243,59 @@ export function inferMutationAliasingEffects(
     }
   }
   return;
+}
+
+/**
+ * Finds references to a named function expression's own name that are never
+ * otherwise defined within the function (i.e. recursive self-references). These
+ * are bound in the function's own scope, so they are neither parameters nor
+ * captured context variables. Returns one representative Place per such
+ * identifier so that it can be seeded in the inference state.
+ */
+function findRecursiveSelfReferences(fn: HIRFunction): Array<Place> {
+  if (fn.id === null) {
+    return [];
+  }
+  // Every identifier that is defined (written) somewhere within the function.
+  const defined = new Set<IdentifierId>();
+  for (const param of fn.params) {
+    const place = param.kind === 'Identifier' ? param : param.place;
+    defined.add(place.identifier.id);
+  }
+  for (const ref of fn.context) {
+    defined.add(ref.identifier.id);
+  }
+  for (const block of fn.body.blocks.values()) {
+    for (const instr of block.instructions) {
+      for (const lvalue of eachInstructionLValue(instr)) {
+        defined.add(lvalue.identifier.id);
+      }
+    }
+  }
+  const selfReferences = new Map<IdentifierId, Place>();
+  const visit = (place: Place): void => {
+    const {identifier} = place;
+    if (
+      identifier.name !== null &&
+      identifier.name.kind === 'named' &&
+      identifier.name.value === fn.id &&
+      !defined.has(identifier.id) &&
+      !selfReferences.has(identifier.id)
+    ) {
+      selfReferences.set(identifier.id, place);
+    }
+  };
+  for (const block of fn.body.blocks.values()) {
+    for (const instr of block.instructions) {
+      for (const operand of eachInstructionValueOperand(instr.value)) {
+        visit(operand);
+      }
+    }
+    for (const operand of eachTerminalOperand(block.terminal)) {
+      visit(operand);
+    }
+  }
+  return Array.from(selfReferences.values());
 }
 
 function findHoistedContextDeclarations(

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bug-infer-mutation-aliasing-effects.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bug-infer-mutation-aliasing-effects.expect.md
@@ -29,18 +29,18 @@ export default function useThunkDispatch(state, dispatch, extraArg) {
 ```
 Found 1 error:
 
-Invariant: [InferMutationAliasingEffects] Expected value kind to be initialized
+Error: Cannot access refs during render
 
-<unknown> thunk$14.
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
 
-error.bug-infer-mutation-aliasing-effects.ts:10:22
-   8 |     function thunk(action) {
-   9 |       if (typeof action === 'function') {
-> 10 |         return action(thunk, () => stateRef.current, extraArg);
-     |                       ^^^^^ this is uninitialized
-  11 |       } else {
-  12 |         dispatch(action);
-  13 |         return undefined;
+error.bug-infer-mutation-aliasing-effects.ts:5:2
+  3 | export default function useThunkDispatch(state, dispatch, extraArg) {
+  4 |   const stateRef = useRef(state);
+> 5 |   stateRef.current = state;
+    |   ^^^^^^^^^^^^^^^^ Cannot update ref during render
+  6 |
+  7 |   return useCallback(
+  8 |     function thunk(action) {
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/recursive-named-function-expression-within-lambda.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/recursive-named-function-expression-within-lambda.expect.md
@@ -1,0 +1,82 @@
+
+## Input
+
+```javascript
+// @compilationMode:"all"
+
+/**
+ * Regression test for a compiler crash on a named function expression that
+ * references its own name recursively from within a lambda:
+ *
+ *   Invariant: [InferMutationAliasingEffects] Expected value kind to be initialized
+ *
+ * The self-reference (`recur` below) is bound in the function's own scope, so
+ * it is neither a parameter nor a captured context variable and was never
+ * seeded in the mutation/aliasing inference state.
+ */
+function Component(props) {
+  const run = () => {
+    const apply = fn => fn(props.count);
+    return apply(function recur(n) {
+      if (n <= 0) {
+        return 0;
+      }
+      return n + recur(n - 1);
+    });
+  };
+  return run();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{count: 4}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @compilationMode:"all"
+
+/**
+ * Regression test for a compiler crash on a named function expression that
+ * references its own name recursively from within a lambda:
+ *
+ *   Invariant: [InferMutationAliasingEffects] Expected value kind to be initialized
+ *
+ * The self-reference (`recur` below) is bound in the function's own scope, so
+ * it is neither a parameter nor a captured context variable and was never
+ * seeded in the mutation/aliasing inference state.
+ */
+function Component(props) {
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== props.count) {
+    const run = () => {
+      const apply = (fn) => fn(props.count);
+      return apply(function recur(n) {
+        if (n <= 0) {
+          return 0;
+        }
+        return n + recur(n - 1);
+      });
+    };
+    t0 = run();
+    $[0] = props.count;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ count: 4 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) 10

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/recursive-named-function-expression-within-lambda.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/recursive-named-function-expression-within-lambda.js
@@ -1,0 +1,29 @@
+// @compilationMode:"all"
+
+/**
+ * Regression test for a compiler crash on a named function expression that
+ * references its own name recursively from within a lambda:
+ *
+ *   Invariant: [InferMutationAliasingEffects] Expected value kind to be initialized
+ *
+ * The self-reference (`recur` below) is bound in the function's own scope, so
+ * it is neither a parameter nor a captured context variable and was never
+ * seeded in the mutation/aliasing inference state.
+ */
+function Component(props) {
+  const run = () => {
+    const apply = fn => fn(props.count);
+    return apply(function recur(n) {
+      if (n <= 0) {
+        return 0;
+      }
+      return n + recur(n - 1);
+    });
+  };
+  return run();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{count: 4}],
+};


### PR DESCRIPTION
## Summary

Fixes #37058.

The React Compiler crashes on a **named function expression that references its
own name recursively**:

```js
function Component() {
  return <HelloWorld onClick={() => {
    foo(function bar() {
      if (Math.random() > .5) {
        baz();
      } else {
        qux(bar); // recursive self-reference
      }
    });
  }} />;
}
```

```js
Invariant: [InferMutationAliasingEffects] Expected value kind to be initialized
<unknown> bar$5.
> 7 |         qux(bar);
    |             ^^^ this is uninitialized
 ```