### PR TITLE
[DevTools] Buffer Bridge messages during extension reconnects

### DIFF
--- a/packages/react-devtools-extensions/src/background/index.js
+++ b/packages/react-devtools-extensions/src/background/index.js
@@ -19,6 +19,11 @@ import {
   handleReactDevToolsHookMessage,
   handleFetchResourceContentScriptMessage,
 } from './messageHandlers';
+import {
+  EXTENSION_BRIDGE_CONNECTION_DISCONNECTED,
+  EXTENSION_BRIDGE_CONNECTION_READY,
+} from '../constants';
+import type {ExtensionBridgeConnectionType} from '../constants';
 
 const ports: {
   // TODO: Check why we convert tab IDs to strings, and if we can avoid it
@@ -156,12 +161,28 @@ function connectExtensionAndProxyPorts(
   }
   const proxyPort = maybeProxyPort;
 
+  function sendBridgeConnectionMessage(
+    port: ExtensionRuntimePort,
+    type: ExtensionBridgeConnectionType,
+  ) {
+    try {
+      port.postMessage({
+        source: 'react-devtools-background',
+        payload: {type},
+      });
+    } catch (error) {
+      // The port disconnected before the status update could be delivered.
+    }
+  }
+
   // $FlowFixMe[incompatible-type]
   if (ports[tabId].disconnectPipe) {
     throw new Error(
       `Attempted to connect already connected ports for tab with id ${tabId}`,
     );
   }
+
+  let didDisconnect = false;
 
   function extensionPortMessageListener(message: mixed) {
     try {
@@ -188,8 +209,22 @@ function connectExtensionAndProxyPorts(
   }
 
   function disconnectListener() {
+    if (didDisconnect) {
+      return;
+    }
+    didDisconnect = true;
+
     extensionPort.onMessage.removeListener(extensionPortMessageListener);
     proxyPort.onMessage.removeListener(proxyPortMessageListener);
+
+    sendBridgeConnectionMessage(
+      extensionPort,
+      EXTENSION_BRIDGE_CONNECTION_DISCONNECTED,
+    );
+    sendBridgeConnectionMessage(
+      proxyPort,
+      EXTENSION_BRIDGE_CONNECTION_DISCONNECTED,
+    );
 
     // We handle disconnect() calls manually, based on each specific case
     // No need to disconnect other port here
@@ -205,6 +240,11 @@ function connectExtensionAndProxyPorts(
 
   extensionPort.onDisconnect.addListener(disconnectListener);
   proxyPort.onDisconnect.addListener(disconnectListener);
+
+  // The proxy owns the backend message queue. Once both forwarding listeners
+  // are installed, tell it to flush that queue through this pipe. It echoes the
+  // message to the frontend after the queued backend messages have been sent.
+  sendBridgeConnectionMessage(proxyPort, EXTENSION_BRIDGE_CONNECTION_READY);
 }
 
 chrome.runtime.onMessage.addListener((message, sender) => {

--- a/packages/react-devtools-extensions/src/constants.js
+++ b/packages/react-devtools-extensions/src/constants.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export type ExtensionBridgeConnectionType =
+  | 'react-devtools-extension-bridge-connection-ready'
+  | 'react-devtools-extension-bridge-connection-disconnected';
+
+export const EXTENSION_BRIDGE_CONNECTION_READY: ExtensionBridgeConnectionType =
+  'react-devtools-extension-bridge-connection-ready';
+export const EXTENSION_BRIDGE_CONNECTION_DISCONNECTED: ExtensionBridgeConnectionType =
+  'react-devtools-extension-bridge-connection-disconnected';
+
+export function getExtensionBridgeConnectionType(
+  message: mixed,
+): ExtensionBridgeConnectionType | null {
+  if (
+    message === null ||
+    typeof message !== 'object' ||
+    !('source' in message) ||
+    message.source !== 'react-devtools-background' ||
+    !('payload' in message)
+  ) {
+    return null;
+  }
+
+  const payload = message.payload;
+  if (payload === null || typeof payload !== 'object' || !('type' in payload)) {
+    return null;
+  }
+
+  const type = payload.type;
+  if (type === EXTENSION_BRIDGE_CONNECTION_READY) {
+    return EXTENSION_BRIDGE_CONNECTION_READY;
+  }
+  if (type === EXTENSION_BRIDGE_CONNECTION_DISCONNECTED) {
+    return EXTENSION_BRIDGE_CONNECTION_DISCONNECTED;
+  }
+  return null;
+}

--- a/packages/react-devtools-extensions/src/contentScripts/proxy.js
+++ b/packages/react-devtools-extensions/src/contentScripts/proxy.js
@@ -6,9 +6,15 @@
  *
  * @flow
  */
-/* global chrome */
+/* global chrome, ExtensionRuntimePort */
 
 'use strict';
+
+import {
+  EXTENSION_BRIDGE_CONNECTION_DISCONNECTED,
+  EXTENSION_BRIDGE_CONNECTION_READY,
+  getExtensionBridgeConnectionType,
+} from '../constants';
 
 function injectProxy() {
   // Firefox's behaviour for injecting this content script can be unpredictable
@@ -16,6 +22,7 @@ function injectProxy() {
   if (!window.__REACT_DEVTOOLS_PROXY_INJECTED__) {
     window.__REACT_DEVTOOLS_PROXY_INJECTED__ = true;
 
+    listenToMessagesFromBackend();
     connectPort();
     sayHelloToBackendManager();
 
@@ -58,8 +65,42 @@ window.addEventListener('pagehide', function ({target}) {
   delete window.__REACT_DEVTOOLS_PROXY_INJECTED__;
 });
 
-let port = null;
+let port: ExtensionRuntimePort | null = null;
 let backendInitialized: boolean = false;
+let isBridgeConnected: boolean = false;
+let isListeningToMessagesFromBackend: boolean = false;
+const pendingMessages: Array<mixed> = [];
+
+function listenToMessagesFromBackend() {
+  if (!isListeningToMessagesFromBackend) {
+    window.addEventListener('message', handleMessageFromPage);
+    isListeningToMessagesFromBackend = true;
+  }
+}
+
+function flushPendingMessages(): boolean {
+  const currentPort = port;
+  if (!isBridgeConnected || currentPort === null) {
+    return false;
+  }
+
+  let sentCount = 0;
+  while (sentCount < pendingMessages.length) {
+    try {
+      currentPort.postMessage(pendingMessages[sentCount]);
+      sentCount++;
+    } catch (error) {
+      isBridgeConnected = false;
+      break;
+    }
+  }
+
+  if (sentCount > 0) {
+    pendingMessages.splice(0, sentCount);
+  }
+
+  return isBridgeConnected && pendingMessages.length === 0;
+}
 
 function sayHelloToBackendManager() {
   window.postMessage(
@@ -71,7 +112,37 @@ function sayHelloToBackendManager() {
   );
 }
 
-function handleMessageFromDevtools(message: mixed) {
+function handleMessageFromDevtools(
+  sourcePort: ExtensionRuntimePort,
+  message: mixed,
+) {
+  if (port !== sourcePort) {
+    return;
+  }
+
+  switch (getExtensionBridgeConnectionType(message)) {
+    case EXTENSION_BRIDGE_CONNECTION_READY:
+      isBridgeConnected = true;
+      if (flushPendingMessages()) {
+        const currentPort = port;
+        if (currentPort === null) {
+          // The port may disconnect synchronously while its queue is flushed.
+          return;
+        }
+        try {
+          // This travels through the forwarding pipe after all queued backend
+          // messages, so the frontend can safely flush its command queue.
+          currentPort.postMessage(message);
+        } catch (error) {
+          isBridgeConnected = false;
+        }
+      }
+      return;
+    case EXTENSION_BRIDGE_CONNECTION_DISCONNECTED:
+      isBridgeConnected = false;
+      return;
+  }
+
   window.postMessage(
     {
       source: 'react-devtools-content-script',
@@ -91,8 +162,8 @@ function handleMessageFromPage(event: any) {
     case 'react-devtools-bridge': {
       backendInitialized = true;
 
-      // $FlowFixMe[incompatible-use]
-      port.postMessage(event.data.payload);
+      pendingMessages.push(event.data.payload);
+      flushPendingMessages();
       break;
     }
 
@@ -110,8 +181,12 @@ function handleMessageFromPage(event: any) {
   }
 }
 
-function handleDisconnect() {
-  window.removeEventListener('message', handleMessageFromPage);
+function handleDisconnect(disconnectedPort: ExtensionRuntimePort) {
+  if (port !== disconnectedPort) {
+    return;
+  }
+
+  isBridgeConnected = false;
   port = null;
 
   // Mirrors the guard in handlePageShow(): the background script can evict/
@@ -131,16 +206,18 @@ function handleDisconnect() {
 // Creates port from application page to the React DevTools' service worker
 // Which then connects it with extension port
 function connectPort() {
-  port = chrome.runtime.connect({
+  isBridgeConnected = false;
+  const nextPort = chrome.runtime.connect({
     name: 'proxy',
   });
+  port = nextPort;
 
-  window.addEventListener('message', handleMessageFromPage);
+  listenToMessagesFromBackend();
 
-  // $FlowFixMe[incompatible-use]
-  port.onMessage.addListener(handleMessageFromDevtools);
-  // $FlowFixMe[incompatible-use]
-  port.onDisconnect.addListener(handleDisconnect);
+  nextPort.onMessage.addListener(message =>
+    handleMessageFromDevtools(nextPort, message),
+  );
+  nextPort.onDisconnect.addListener(() => handleDisconnect(nextPort));
 }
 
 let evalRequestId = 0;

--- a/packages/react-devtools-extensions/src/main/index.js
+++ b/packages/react-devtools-extensions/src/main/index.js
@@ -48,6 +48,11 @@ import injectBackendManager from './injectBackendManager';
 import registerEventsLogger from './registerEventsLogger';
 import getProfilingFlags from './getProfilingFlags';
 import debounce from './debounce';
+import {
+  EXTENSION_BRIDGE_CONNECTION_DISCONNECTED,
+  EXTENSION_BRIDGE_CONNECTION_READY,
+  getExtensionBridgeConnectionType,
+} from '../constants';
 import './requestAnimationFramePolyfill';
 
 const resolvedParseHookNames = Promise.resolve(parseHookNames);
@@ -56,24 +61,98 @@ const resolvedParseHookNames = Promise.resolve(parseHookNames);
 // wrapper around calling the worker.
 const hookNamesModuleLoaderFunction = () => resolvedParseHookNames;
 
+type PendingBridgeMessage = {
+  event: string,
+  payload: mixed,
+  transferable?: $ReadOnlyArray<mixed>,
+};
+
+function flushPendingBridgeMessages(): void {
+  const currentPort = port;
+  if (!isBridgeConnected || currentPort === null) {
+    return;
+  }
+
+  let sentCount = 0;
+  while (sentCount < pendingBridgeMessages.length) {
+    const {event, payload, transferable} = pendingBridgeMessages[sentCount];
+    try {
+      currentPort.postMessage({event, payload}, transferable);
+      sentCount++;
+    } catch (error) {
+      isBridgeConnected = false;
+      break;
+    }
+  }
+
+  if (sentCount > 0) {
+    pendingBridgeMessages.splice(0, sentCount);
+  }
+}
+
+function handleBridgeConnectionMessage(message: mixed): void {
+  switch (getExtensionBridgeConnectionType(message)) {
+    case EXTENSION_BRIDGE_CONNECTION_READY:
+      isBridgeConnected = true;
+      flushPendingBridgeMessages();
+      break;
+    case EXTENSION_BRIDGE_CONNECTION_DISCONNECTED:
+      isBridgeConnected = false;
+      break;
+  }
+}
+
+function removeBridgePortListener(): void {
+  if (subscribedBridgePort !== null && bridgePortListener !== null) {
+    subscribedBridgePort.onMessage.removeListener(bridgePortListener);
+  }
+  subscribedBridgePort = null;
+  bridgePortListener = null;
+}
+
+function addBridgePortListener(nextPort: ExtensionRuntimePort): void {
+  const bridgeListener = lastSubscribedBridgeListener;
+  if (bridgeListener === null) {
+    return;
+  }
+
+  removeBridgePortListener();
+
+  const nextBridgePortListener = (message: mixed) => {
+    if (port === nextPort) {
+      bridgeListener(message);
+    }
+  };
+  nextPort.onMessage.addListener(nextBridgePortListener);
+  subscribedBridgePort = nextPort;
+  bridgePortListener = nextBridgePortListener;
+}
+
 function createBridge() {
   bridge = new Bridge({
     listen(fn) {
-      const bridgeListener = (message: mixed) => fn(message);
-      // Store the reference so that we unsubscribe from the same object.
-      const portOnMessage = port.onMessage;
-      portOnMessage.addListener(bridgeListener);
+      const currentPort = port;
+      if (currentPort === null) {
+        throw new Error('DevTools port is not connected.');
+      }
+      if (lastSubscribedBridgeListener !== null) {
+        throw new Error('The Bridge already has a Wall listener.');
+      }
 
-      lastSubscribedBridgeListener = bridgeListener;
+      lastSubscribedBridgeListener = fn;
+      addBridgePortListener(currentPort);
 
       return () => {
-        port?.onMessage.removeListener(bridgeListener);
-        lastSubscribedBridgeListener = null;
+        if (lastSubscribedBridgeListener === fn) {
+          lastSubscribedBridgeListener = null;
+          removeBridgePortListener();
+        }
       };
     },
 
     send(event: string, payload: mixed, transferable?: $ReadOnlyArray<mixed>) {
-      port?.postMessage({event, payload}, transferable);
+      pendingBridgeMessages.push({event, payload, transferable});
+      flushPendingBridgeMessages();
     },
   });
 
@@ -490,6 +569,7 @@ function performInTabNavigationCleanup() {
   bridge = null as $FlowFixMe;
   render = null as $FlowFixMe;
   root = null as $FlowFixMe;
+  pendingBridgeMessages.length = 0;
 }
 
 function performFullCleanup() {
@@ -517,9 +597,10 @@ function performFullCleanup() {
   store = null as $FlowFixMe;
   bridge = null as $FlowFixMe;
   render = null as $FlowFixMe;
+  pendingBridgeMessages.length = 0;
 
   port?.disconnect();
-  port = null as $FlowFixMe;
+  port = null;
 }
 
 function connectExtensionPort(): void {
@@ -528,8 +609,15 @@ function connectExtensionPort(): void {
   }
 
   const tabId = chrome.devtools.inspectedWindow.tabId;
-  port = chrome.runtime.connect({
+  isBridgeConnected = false;
+  const nextPort = chrome.runtime.connect({
     name: String(tabId),
+  });
+  port = nextPort;
+  nextPort.onMessage.addListener(message => {
+    if (port === nextPort) {
+      handleBridgeConnectionMessage(message);
+    }
   });
 
   // If DevTools port was reconnected and Bridge was already created
@@ -537,16 +625,18 @@ function connectExtensionPort(): void {
   // This could happen if service worker dies and all ports are disconnected,
   // but later user continues the session and Chrome reconnects all ports
   // Bridge object is still in-memory, though
-  if (lastSubscribedBridgeListener) {
-    port.onMessage.addListener(lastSubscribedBridgeListener);
-  }
+  addBridgePortListener(nextPort);
 
   // This port may be disconnected by Chrome at some point, this callback
   // will be executed only if this port was disconnected from the other end
   // so, when we call `port.disconnect()` from this script,
   // this should not trigger this callback and port reconnection
-  port.onDisconnect.addListener(() => {
-    port = null as $FlowFixMe;
+  nextPort.onDisconnect.addListener(() => {
+    if (port !== nextPort) {
+      return;
+    }
+    isBridgeConnected = false;
+    port = null;
     connectExtensionPort();
   });
 }
@@ -600,7 +690,9 @@ function mountReactDevToolsWhenReactHasLoaded() {
 }
 
 let bridge: FrontendBridge = null as $FlowFixMe;
-let lastSubscribedBridgeListener = null;
+let lastSubscribedBridgeListener: ((message: mixed) => void) | null = null;
+let subscribedBridgePort: ExtensionRuntimePort | null = null;
+let bridgePortListener: ((message: mixed) => void) | null = null;
 let store: Store = null as $FlowFixMe;
 
 let profilingData = null;
@@ -622,7 +714,9 @@ let root: RootType = null as $FlowFixMe;
 
 let currentSelectedSource: null | SourceSelection = null;
 
-let port: ExtensionRuntimePort = null as $FlowFixMe;
+let port: ExtensionRuntimePort | null = null;
+let isBridgeConnected: boolean = false;
+const pendingBridgeMessages: Array<PendingBridgeMessage> = [];
 
 // In case when multiple navigation events emitted in a short period of time
 // This debounced callback primarily used to avoid mounting React DevTools multiple times, which results

--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -14,6 +14,18 @@ import type {
   FrontendBridge,
 } from 'react-devtools-shared/src/bridge';
 
+type TestBridgeMessage = {event: string, payload: mixed};
+type TestBridgeWall = {
+  disconnect: () => void,
+  reconnect: () => void,
+  listen: (callback: (message: mixed) => void) => () => void,
+  send: (
+    event: string,
+    payload: mixed,
+    transferable?: $ReadOnlyArray<mixed>,
+  ) => void,
+};
+
 const {getTestFlags} = require('../../../../scripts/jest/TestFlags');
 
 // Argument is serialized when passed from jest-cli script through to setupTests.
@@ -247,21 +259,58 @@ beforeEach(() => {
     disableSecondConsoleLogDimmingInStrictMode: false,
   });
 
-  const bridgeListeners = [];
-  const bridge = new Bridge({
+  let bridgeListeners: Array<(message: mixed) => void> = [];
+  let disconnectedBridgeListeners: Array<(message: mixed) => void> | null =
+    null;
+  let pendingBridgeMessages: Array<TestBridgeMessage> = [];
+  const bridgeWall: TestBridgeWall = {
+    disconnect() {
+      if (disconnectedBridgeListeners === null) {
+        disconnectedBridgeListeners = bridgeListeners;
+        bridgeListeners = [];
+      }
+    },
+    reconnect() {
+      if (disconnectedBridgeListeners !== null) {
+        bridgeListeners = disconnectedBridgeListeners;
+        disconnectedBridgeListeners = null;
+
+        const messages = pendingBridgeMessages;
+        pendingBridgeMessages = [];
+        messages.forEach(message => {
+          bridgeListeners.forEach(callback => callback(message));
+        });
+      }
+    },
     listen(callback) {
-      bridgeListeners.push(callback);
+      const listeners =
+        disconnectedBridgeListeners !== null
+          ? disconnectedBridgeListeners
+          : bridgeListeners;
+      listeners.push(callback);
       return () => {
-        const index = bridgeListeners.indexOf(callback);
+        let index = bridgeListeners.indexOf(callback);
         if (index >= 0) {
           bridgeListeners.splice(index, 1);
+        }
+        if (disconnectedBridgeListeners !== null) {
+          index = disconnectedBridgeListeners.indexOf(callback);
+          if (index >= 0) {
+            disconnectedBridgeListeners.splice(index, 1);
+          }
         }
       };
     },
     send(event: string, payload: mixed, transferable?: $ReadOnlyArray<mixed>) {
-      bridgeListeners.forEach(callback => callback({event, payload}));
+      const message = {event, payload};
+      if (disconnectedBridgeListeners === null) {
+        bridgeListeners.forEach(callback => callback(message));
+      } else {
+        pendingBridgeMessages.push(message);
+      }
     },
-  });
+  };
+  const bridge = new Bridge(bridgeWall);
 
   const store = new Store(((bridge: any): FrontendBridge), {
     supportsTimeline: true,

--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -199,6 +199,58 @@ describe('Store', () => {
     store.removeListener('error', errorListener);
   });
 
+  // @reactVersion >= 18.0
+  it('receives operations queued while the frontend transport reconnects', () => {
+    const App = ({children}) => children ?? null;
+    const Parent = ({children}) => children ?? null;
+    const Child = () => null;
+
+    act(() => render(<App />));
+
+    const bridgeWall = (bridge.wall: any);
+
+    bridgeWall.disconnect();
+    try {
+      act(() =>
+        render(
+          <App>
+            <Parent />
+          </App>,
+        ),
+      );
+
+      expect(store).toMatchInlineSnapshot(`
+        [root]
+            <App>
+      `);
+    } finally {
+      bridgeWall.reconnect();
+    }
+
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <App>
+            <Parent>
+    `);
+
+    act(() =>
+      render(
+        <App>
+          <Parent>
+            <Child />
+          </Parent>
+        </App>,
+      ),
+    );
+
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <App>
+          ▾ <Parent>
+              <Child>
+    `);
+  });
+
   // This test is not the same cause as what's reported on GitHub,
   // but the resulting behavior (owner mounting after descendant) is the same.
   // Thec ase below is admittedly contrived and relies on side effects.


### PR DESCRIPTION
Buffers Bridge messages during extension port reconnects and adds a readiness handshake for ordered queue flushing. Includes regression coverage for reconnect delivery and listener cleanup.

Potential scenario could be a long user session, where Chrome kills one of the extension ports to save resources and then user re-connects by navigating back to the DevTools UI.