### PR TITLE
Fix infinite loop in dispatchEventForPluginEventSystem when a document singleton is rendered outside its root container

### DIFF
--- a/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
@@ -627,6 +627,15 @@ export function dispatchEventForPluginEventSystem(
       // sub-tree for that root and make that our ancestor instance.
       let node: null | Fiber = targetInst;
 
+      // Tracks the host fibers we have already climbed to as ancestor
+      // candidates. In a well-formed tree each candidate is only ever visited
+      // once. If a document singleton (<html>/<head>/<body>) is rendered
+      // outside its own root container, the host hierarchy becomes inverted
+      // (the singleton resolves to a node that is an ancestor of the root
+      // container), which makes this traversal revisit the same fiber forever.
+      // Guarding against a revisit keeps the loop terminating in that case.
+      let visitedAncestors: null | Set<Fiber> = null;
+
       mainLoop: while (true) {
         if (node === null) {
           return;
@@ -676,6 +685,20 @@ export function dispatchEventForPluginEventSystem(
               parentTag === HostHoistable ||
               parentTag === HostSingleton
             ) {
+              if (
+                visitedAncestors !== null &&
+                visitedAncestors.has(parentNode)
+              ) {
+                // We have already climbed to this fiber, so the host hierarchy
+                // is inverted (see the comment where visitedAncestors is
+                // declared). Stop climbing and dispatch at the current
+                // ancestor instead of looping forever.
+                break mainLoop;
+              }
+              if (visitedAncestors === null) {
+                visitedAncestors = new Set();
+              }
+              visitedAncestors.add(parentNode);
               node = ancestorInst = parentNode;
               continue mainLoop;
             }


### PR DESCRIPTION
## Summary

`dispatchEventForPluginEventSystem` walks up the fiber tree to map an event
target onto the ancestor instance belonging to the current root container.
When a document singleton (`<html>`/`<head>`/`<body>`) is rendered **outside**
its own root container — e.g. a full `<html>` document tree mounted into a
Testing Library container `<div>` — the singleton resolves to a DOM node that
is an *ancestor* of the root container. This inverts the host hierarchy: the
`HostRoot`'s `containerInfo` never matches `targetContainer`, so the
`mainLoop` climb keeps re-resolving to the same `HostSingleton` via
`getClosestInstanceFromNode` and hits `continue mainLoop` forever — a
synchronous infinite loop that pins the CPU and hangs event dispatch.

## Fix

Track the host fibers already visited as ancestor candidates during the climb.
If the traversal is about to revisit a fiber it has already climbed to, the
hierarchy is inverted, so we `break mainLoop` and dispatch at the current
ancestor instead of looping. Well-formed trees never revisit an ancestor, so
their dispatch behavior is unchanged.

## Testing

Reproduced via a nested-`<html>` render + click that previously hung
indefinitely; with the fix the event dispatches and completes normally, while
React still emits the existing `<html> cannot be a child of <div>` dev warning.
Verified that plain clicks and portaled-content clicks in well-formed trees
continue to dispatch correctly (no regression).

Fixes #37065