### PR TITLE
[eslint-plugin-react-hooks] Read the additionalHooks option declared by rules-of-hooks schema

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -627,6 +627,42 @@ const allTests = {
     },
     {
       code: normalizeIndent`
+        // Valid: useEffectEvent can be called in custom effect hooks configured via rule options
+        function MyComponent({ theme }) {
+          const onClick = useEffectEvent(() => {
+            showNotification(theme);
+          });
+          useMyEffect(() => {
+            onClick();
+          });
+          useServerEffect(() => {
+            onClick();
+          });
+        }
+      `,
+      options: [{additionalHooks: '(useMyEffect|useServerEffect)'}],
+    },
+    {
+      code: normalizeIndent`
+        // Valid: rule-level additionalHooks takes precedence over settings
+        function MyComponent({ theme }) {
+          const onClick = useEffectEvent(() => {
+            showNotification(theme);
+          });
+          useMyEffect(() => {
+            onClick();
+          });
+        }
+      `,
+      options: [{additionalHooks: 'useMyEffect'}],
+      settings: {
+        'react-hooks': {
+          additionalEffectHooks: 'useServerEffect',
+        },
+      },
+    },
+    {
+      code: normalizeIndent`
         // Valid because functions created with useEffectEvent can be called in a useEffect.
         function MyComponent({ theme }) {
           const onClick = useEffectEvent(() => {
@@ -1751,6 +1787,42 @@ const allTests = {
       settings: {
         'react-hooks': {
           additionalEffectHooks: 'useMyEffect',
+        },
+      },
+      errors: [useEffectEventError('onClick', true)],
+    },
+    {
+      code: normalizeIndent`
+        // Invalid: useEffectEvent should not be callable in hooks not matching the options regex
+        function MyComponent({ theme }) {
+          const onClick = useEffectEvent(() => {
+            showNotification(theme);
+          });
+          useWrongHook(() => {
+            onClick();
+          });
+        }
+      `,
+      options: [{additionalHooks: 'useMyEffect'}],
+      errors: [useEffectEventError('onClick', true)],
+    },
+    {
+      code: normalizeIndent`
+        // Invalid: rule-level additionalHooks takes precedence over settings,
+        // so a hook matched only by the settings regex is not an effect hook
+        function MyComponent({ theme }) {
+          const onClick = useEffectEvent(() => {
+            showNotification(theme);
+          });
+          useWrongHook(() => {
+            onClick();
+          });
+        }
+      `,
+      options: [{additionalHooks: 'useMyEffect'}],
+      settings: {
+        'react-hooks': {
+          additionalEffectHooks: 'useWrongHook',
         },
       },
       errors: [useEffectEventError('onClick', true)],

--- a/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
@@ -212,10 +212,14 @@ const rule = {
     ],
   },
   create(context: Rule.RuleContext) {
+    const rawOptions = context.options && context.options[0];
     const settings = context.settings || {};
 
+    // Use rule-level additionalHooks if provided, otherwise fall back to settings
     const additionalEffectHooks =
-      getAdditionalEffectHooksFromSettings(settings);
+      rawOptions && rawOptions.additionalHooks
+        ? new RegExp(rawOptions.additionalHooks)
+        : getAdditionalEffectHooksFromSettings(settings);
 
     let lastEffect: CallExpression | null = null;
     const codePathReactHooksMapStack: Array<


### PR DESCRIPTION
## Summary

`rules-of-hooks` has declared an `additionalHooks` option in its `meta.schema` since #34497, but `create()` never reads `context.options` — the declared option is accepted by ESLint's config validation and then silently ignored; only `settings['react-hooks'].additionalEffectHooks` is consulted.

This wires the option up using the exact pattern `exhaustive-deps` has used since #34637: the rule-level `additionalHooks` takes precedence, and the shared `additionalEffectHooks` setting remains the fallback.

## How did you test this change?

Added four RuleTester cases to `ESLintRulesOfHooks-test.js`, mirroring the existing settings-based cases:

- valid: `useEffectEvent` functions may be called inside custom effect hooks configured via the rule option;
- valid: the rule-level option takes precedence over the setting;
- invalid: hooks not matching the option's regex still report;
- invalid: when the option is set, a hook matched only by the settings regex reports.

They run in the existing parser matrix (ESLint v7/v9 × babel/hermes) via `yarn test packages/eslint-plugin-react-hooks`.