### PR TITLE
[Flight] Limit fake JSX call site stacks to 10 frames

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -4031,11 +4031,24 @@ const createFakeJSXCallStackInDEV: (
     ) as any)
   : (null as any);
 
+// v8 (Chromium, Node.js) defaults to 10
+// SpiderMonkey (Firefox) does not support Error.stackTraceLimit
+// JSC (Safari) defaults to 100
+// The lower the limit, the more likely we'll not reach react_stack_bottom_frame
+// The higher the limit, the slower Error() is when not inspecting with a debugger.
+// When inspecting with a debugger, Error.stackTraceLimit has no impact on Error() performance (in v8).
+const ownerStackTraceLimit = 10;
+
 /** @noinline */
 function fakeJSXCallSite() {
   // This extra call frame represents the JSX creation function. We always pop this frame
   // off before presenting so it needs to be part of the stack.
-  return new Error('react-stack-top-frame');
+  let error;
+  const previousStackTraceLimit = Error.stackTraceLimit;
+  Error.stackTraceLimit = ownerStackTraceLimit;
+  error = Error('react-stack-top-frame'); // eslint-disable-line prefer-const
+  Error.stackTraceLimit = previousStackTraceLimit;
+  return error;
 }
 
 function initializeFakeStack(

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -3915,6 +3915,25 @@ describe('ReactFlight', () => {
     expect(ReactNoop).toMatchRenderedOutput(<span>Hello, Seb</span>);
   });
 
+  it('restores the stack trace limit after recreating JSX call sites', async () => {
+    function Component() {
+      return ReactServer.createElement('div');
+    }
+
+    const transport = ReactNoopFlightServer.render(
+      ReactServer.createElement(Component),
+    );
+    const previousStackTraceLimit = Error.stackTraceLimit;
+    Error.stackTraceLimit = 50;
+    try {
+      await ReactNoopFlightClient.read(transport);
+
+      expect(Error.stackTraceLimit).toBe(50);
+    } finally {
+      Error.stackTraceLimit = previousStackTraceLimit;
+    }
+  });
+
   // @gate __DEV__
   it('can get the component owner stacks during rendering in dev', () => {
     let stack;


### PR DESCRIPTION
## Summary

Extend the stack-capture optimization from #34864 to Flight's development fake JSX call sites. `fakeJSXCallSite` now captures at `ownerStackTraceLimit` (10) and restores the ambient limit afterward.

Benchmarks were run without a debugger attached.

## Benchmark results

Standalone benchmark used: 
[rsc-stack-trace-standalone.zip](https://github.com/user-attachments/files/30262123/rsc-stack-trace-standalone.zip)


This change reduces the cost of reconstructing development-mode JSX call stacks by temporarily setting `Error.stackTraceLimit` to `10` while creating `Error("react-stack-top-frame")`.

### Methodology

The standalone benchmark uses React directly, without Next.js, HTTP, or a browser.

- Component with a lot of JSX
- Four nested Server Component levels
- Payload generated once with `react-server-dom-turbopack/server.node`
- Each sample decodes the payload with `createFromReadableStream()`
- The decoded tree is rendered to HTML with `renderToString()`
- Payload generation is excluded from timing
- Ambient `Error.stackTraceLimit` is `50`
- 100 samples per variant with alternating execution order
- One warmup render per variant
- No debugger or inspector attached
- The before/after client files differ only in `fakeJSXCallSite`

### Results

#### High-level overview

Case | Before | After | Improvement
-- | -- | -- | --
Small | 0.40 ms/render | 0.32 ms/render | 0.07 ms (18.3%)
Sprite | 31.78 ms/render | 8.35 ms/render | 23.43 ms (73.7%)
Large | 48.63 ms/render | 13.68 ms/render | 34.95 ms (71.9%)
100 fuzzy cases (average) | 12.09 ms/render | 5.77 ms/render | 6.33 ms (52.3%)

</body></html>

#### Detailed run results

<details>
<summary>Detailed run</summary>

Index | Case | Before (ms) | After (ms) | Improvement (ms) | Improvement
-- | -- | -- | -- | -- | --
0 | small | 0.40 | 0.32 | 0.07 | 18.3%
1 | sprite | 31.78 | 8.35 | 23.43 | 73.7%
2 | large | 48.63 | 13.68 | 34.95 | 71.9%
3 | fuzzy-1 | 16.70 | 7.97 | 8.74 | 52.3%
4 | fuzzy-2 | 19.15 | 9.06 | 10.09 | 52.7%
5 | fuzzy-3 | 18.03 | 8.56 | 9.47 | 52.5%
6 | fuzzy-4 | 22.92 | 10.78 | 12.15 | 53.0%
7 | fuzzy-5 | 17.52 | 8.21 | 9.31 | 53.1%
8 | fuzzy-6 | 13.60 | 6.45 | 7.15 | 52.6%
9 | fuzzy-7 | 1.96 | 1.08 | 0.88 | 44.8%
10 | fuzzy-8 | 5.12 | 2.56 | 2.56 | 50.0%
11 | fuzzy-9 | 6.10 | 3.03 | 3.07 | 50.4%
12 | fuzzy-10 | 12.71 | 6.05 | 6.66 | 52.4%
13 | fuzzy-11 | 12.96 | 6.18 | 6.78 | 52.3%
14 | fuzzy-12 | 8.15 | 3.94 | 4.22 | 51.7%
15 | fuzzy-13 | 14.19 | 6.73 | 7.46 | 52.5%
16 | fuzzy-14 | 11.57 | 5.53 | 6.03 | 52.2%
17 | fuzzy-15 | 6.97 | 3.40 | 3.57 | 51.3%
18 | fuzzy-16 | 15.68 | 7.46 | 8.22 | 52.4%
19 | fuzzy-17 | 16.73 | 7.93 | 8.80 | 52.6%
20 | fuzzy-18 | 10.52 | 5.04 | 5.48 | 52.1%
21 | fuzzy-19 | 2.95 | 1.53 | 1.42 | 48.2%
22 | fuzzy-20 | 18.20 | 8.61 | 9.59 | 52.7%
23 | fuzzy-21 | 11.19 | 5.35 | 5.85 | 52.2%
24 | fuzzy-22 | 15.38 | 7.29 | 8.09 | 52.6%
25 | fuzzy-23 | 3.71 | 1.88 | 1.83 | 49.4%
26 | fuzzy-24 | 8.98 | 4.32 | 4.66 | 51.9%
27 | fuzzy-25 | 14.84 | 7.04 | 7.80 | 52.5%
28 | fuzzy-26 | 12.92 | 6.14 | 6.77 | 52.5%
29 | fuzzy-27 | 10.53 | 5.04 | 5.49 | 52.2%
30 | fuzzy-28 | 11.07 | 5.30 | 5.77 | 52.1%
31 | fuzzy-29 | 6.33 | 3.09 | 3.23 | 51.1%
32 | fuzzy-30 | 20.62 | 9.72 | 10.90 | 52.9%
33 | fuzzy-31 | 16.46 | 7.78 | 8.68 | 52.7%
34 | fuzzy-32 | 10.23 | 4.89 | 5.34 | 52.2%
35 | fuzzy-33 | 13.81 | 6.57 | 7.24 | 52.4%
36 | fuzzy-34 | 15.10 | 7.14 | 7.96 | 52.7%
37 | fuzzy-35 | 1.86 | 1.01 | 0.85 | 45.6%
38 | fuzzy-36 | 22.59 | 10.62 | 11.97 | 53.0%
39 | fuzzy-37 | 12.98 | 6.18 | 6.80 | 52.4%
40 | fuzzy-38 | 17.64 | 8.31 | 9.34 | 52.9%
41 | fuzzy-39 | 3.31 | 1.70 | 1.61 | 48.6%
42 | fuzzy-40 | 15.74 | 7.45 | 8.29 | 52.7%
43 | fuzzy-41 | 20.50 | 9.59 | 10.91 | 53.2%
44 | fuzzy-42 | 14.93 | 7.07 | 7.86 | 52.6%
45 | fuzzy-43 | 23.67 | 11.09 | 12.58 | 53.2%
46 | fuzzy-44 | 20.09 | 9.41 | 10.68 | 53.2%
47 | fuzzy-45 | 2.52 | 1.33 | 1.19 | 47.2%
48 | fuzzy-46 | 3.03 | 1.56 | 1.47 | 48.5%
49 | fuzzy-47 | 15.50 | 7.34 | 8.17 | 52.7%
50 | fuzzy-48 | 20.31 | 9.55 | 10.76 | 53.0%
51 | fuzzy-49 | 9.94 | 4.78 | 5.16 | 51.9%
52 | fuzzy-50 | 13.59 | 6.43 | 7.16 | 52.7%
53 | fuzzy-51 | 4.95 | 2.45 | 2.50 | 50.4%
54 | fuzzy-52 | 6.40 | 3.13 | 3.27 | 51.1%
55 | fuzzy-53 | 3.11 | 1.61 | 1.50 | 48.1%
56 | fuzzy-54 | 7.38 | 3.57 | 3.81 | 51.7%
57 | fuzzy-55 | 11.43 | 5.48 | 5.95 | 52.1%
58 | fuzzy-56 | 5.07 | 2.52 | 2.55 | 50.3%
59 | fuzzy-57 | 17.88 | 8.47 | 9.41 | 52.6%
60 | fuzzy-58 | 12.67 | 6.02 | 6.65 | 52.5%
61 | fuzzy-59 | 10.36 | 4.95 | 5.41 | 52.2%
62 | fuzzy-60 | 8.52 | 4.12 | 4.40 | 51.6%
63 | fuzzy-61 | 13.73 | 6.53 | 7.20 | 52.4%
64 | fuzzy-62 | 18.10 | 8.55 | 9.56 | 52.8%
65 | fuzzy-63 | 6.90 | 3.37 | 3.53 | 51.2%
66 | fuzzy-64 | 20.29 | 9.53 | 10.76 | 53.0%
67 | fuzzy-65 | 4.09 | 2.09 | 2.01 | 49.0%
68 | fuzzy-66 | 4.86 | 2.42 | 2.44 | 50.3%
69 | fuzzy-67 | 23.26 | 10.96 | 12.30 | 52.9%
70 | fuzzy-68 | 9.70 | 4.66 | 5.04 | 52.0%
71 | fuzzy-69 | 19.19 | 9.02 | 10.17 | 53.0%
72 | fuzzy-70 | 18.71 | 8.85 | 9.86 | 52.7%
73 | fuzzy-71 | 18.43 | 8.70 | 9.73 | 52.8%
74 | fuzzy-72 | 6.25 | 3.06 | 3.19 | 51.0%
75 | fuzzy-73 | 18.09 | 8.59 | 9.49 | 52.5%
76 | fuzzy-74 | 4.96 | 2.45 | 2.50 | 50.5%
77 | fuzzy-75 | 6.99 | 3.40 | 3.58 | 51.3%
78 | fuzzy-76 | 11.54 | 5.52 | 6.02 | 52.2%
79 | fuzzy-77 | 11.04 | 5.27 | 5.77 | 52.2%
80 | fuzzy-78 | 13.45 | 6.40 | 7.05 | 52.4%
81 | fuzzy-79 | 2.36 | 1.26 | 1.10 | 46.8%
82 | fuzzy-80 | 18.97 | 8.94 | 10.04 | 52.9%
83 | fuzzy-81 | 20.24 | 9.47 | 10.78 | 53.2%
84 | fuzzy-82 | 18.41 | 8.66 | 9.75 | 53.0%
85 | fuzzy-83 | 17.20 | 8.11 | 9.10 | 52.9%
86 | fuzzy-84 | 11.76 | 5.60 | 6.15 | 52.3%
87 | fuzzy-85 | 11.55 | 5.51 | 6.04 | 52.3%
88 | fuzzy-86 | 2.37 | 1.26 | 1.11 | 46.8%
89 | fuzzy-87 | 2.64 | 1.40 | 1.25 | 47.2%
90 | fuzzy-88 | 20.12 | 9.46 | 10.66 | 53.0%
91 | fuzzy-89 | 22.02 | 10.37 | 11.66 | 52.9%
92 | fuzzy-90 | 2.59 | 1.36 | 1.23 | 47.5%
93 | fuzzy-91 | 16.63 | 7.85 | 8.78 | 52.8%
94 | fuzzy-92 | 11.10 | 5.30 | 5.79 | 52.2%
95 | fuzzy-93 | 7.23 | 3.51 | 3.72 | 51.5%
96 | fuzzy-94 | 6.55 | 3.21 | 3.34 | 51.0%
97 | fuzzy-95 | 15.03 | 7.12 | 7.91 | 52.6%
98 | fuzzy-96 | 3.03 | 1.56 | 1.47 | 48.5%
99 | fuzzy-97 | 14.21 | 6.78 | 7.43 | 52.3%
100 | fuzzy-98 | 12.84 | 6.17 | 6.67 | 52.0%
101 | fuzzy-99 | 7.42 | 3.63 | 3.79 | 51.1%
102 | fuzzy-100 | 6.54 | 3.25 | 3.30 | 50.4%


</details>

### Scope

This is a deliberately stack-heavy development benchmark. It measures combined RSC decoding and server HTML rendering, including React’s development owner-stack machinery.

It does not imply a 66% improvement to production rendering or every development request. It demonstrates that limiting these fake stacks substantially reduces CPU and memory pressure when processing large RSC element trees.

## How did you test this change?

- Added a DEV regression test covering the 10-frame cap and ambient-limit restoration.
