### PR TITLE
Warn when <title> has invalid children on the client

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -60,6 +60,7 @@ import getAttributeAlias from '../shared/getAttributeAlias';
 import possibleStandardNames from '../shared/possibleStandardNames';
 import {validateProperties as validateARIAProperties} from '../shared/ReactDOMInvalidARIAHook';
 import {validateProperties as validateInputProperties} from '../shared/ReactDOMNullInputValuePropHook';
+import {validateProperties as validateTitleProperties} from '../shared/ReactDOMTitle';
 import {validateProperties as validateUnknownProperties} from '../shared/ReactDOMUnknownPropertyHook';
 import sanitizeURL from '../shared/sanitizeURL';
 
@@ -100,6 +101,7 @@ function validatePropertiesInDevelopment(type: string, props: any) {
       registrationNameDependencies,
       possibleRegistrationNames,
     });
+    validateTitleProperties(type, props);
     if (
       props.contentEditable &&
       !props.suppressContentEditableWarning &&

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -68,6 +68,7 @@ import getAttributeAlias from '../shared/getAttributeAlias';
 import {checkControlledValueProps} from '../shared/ReactControlledValuePropTypes';
 import {validateProperties as validateARIAProperties} from '../shared/ReactDOMInvalidARIAHook';
 import {validateProperties as validateInputProperties} from '../shared/ReactDOMNullInputValuePropHook';
+import {validateProperties as validateTitleProperties} from '../shared/ReactDOMTitle';
 import {validateProperties as validateUnknownProperties} from '../shared/ReactDOMUnknownPropertyHook';
 import warnValidStyle from '../shared/warnValidStyle';
 import {getCrossOriginString} from '../shared/crossOriginStrings';
@@ -3602,53 +3603,7 @@ function pushTitle(
   const noscriptTagInScope = formatContext.tagScope & NOSCRIPT_SCOPE;
   const isFallback = formatContext.tagScope & FALLBACK_SCOPE;
   if (__DEV__) {
-    if (hasOwnProperty.call(props, 'children')) {
-      const children = props.children;
-
-      const child = Array.isArray(children)
-        ? children.length < 2
-          ? children[0]
-          : null
-        : children;
-
-      if (Array.isArray(children) && children.length > 1) {
-        console.error(
-          'React expects the `children` prop of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found an Array with length %s instead.' +
-            ' Browsers treat all child Nodes of <title> tags as Text content and React expects to be able to convert `children` of <title> tags to a single string value' +
-            ' which is why Arrays of length greater than 1 are not supported. When using JSX it can be common to combine text nodes and value nodes.' +
-            ' For example: <title>hello {nameOfUser}</title>. While not immediately apparent, `children` in this case is an Array with length 2. If your `children` prop' +
-            ' is using this form try rewriting it using a template string: <title>{`hello ${nameOfUser}`}</title>.',
-          children.length,
-        );
-      } else if (typeof child === 'function' || typeof child === 'symbol') {
-        const childType =
-          typeof child === 'function' ? 'a Function' : 'a Sybmol';
-        console.error(
-          'React expect children of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found %s instead.' +
-            ' Browsers treat all child Nodes of <title> tags as Text content and React expects to be able to convert children of <title>' +
-            ' tags to a single string value.',
-          childType,
-        );
-        // $FlowFixMe[invalid-compare]
-        // $FlowFixMe[constant-condition]
-      } else if (child && child.toString === {}.toString) {
-        if (child.$$typeof != null) {
-          console.error(
-            'React expects the `children` prop of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found an object that appears to be' +
-              ' a React element which never implements a suitable `toString` method. Browsers treat all child Nodes of <title> tags as Text content and React expects to' +
-              ' be able to convert children of <title> tags to a single string value which is why rendering React elements is not supported. If the `children` of <title> is' +
-              ' a React Component try moving the <title> tag into that component. If the `children` of <title> is some HTML markup change it to be Text only to be valid HTML.',
-          );
-        } else {
-          console.error(
-            'React expects the `children` prop of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found an object that does not implement' +
-              ' a suitable `toString` method. Browsers treat all child Nodes of <title> tags as Text content and React expects to be able to convert children of <title> tags' +
-              ' to a single string value. Using the default `toString` method available on every object is almost certainly an error. Consider whether the `children` of this <title>' +
-              ' is an object in error and change it to a string or number value if so. Otherwise implement a `toString` method that React can use to produce a valid <title>.',
-          );
-        }
-      }
-    }
+    validateTitleProperties('title', props);
   }
 
   if (

--- a/packages/react-dom-bindings/src/shared/ReactDOMTitle.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMTitle.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import hasOwnProperty from 'shared/hasOwnProperty';
+
+export function validateProperties(type: string, props: Object) {
+  if (type !== 'title') {
+    return;
+  }
+
+  if (__DEV__) {
+    if (hasOwnProperty.call(props, 'children')) {
+      const children = props.children;
+
+      const child = Array.isArray(children)
+        ? children.length < 2
+          ? children[0]
+          : null
+        : children;
+
+      if (Array.isArray(children) && children.length > 1) {
+        console.error(
+          'React expects the `children` prop of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found an Array with length %s instead.' +
+            ' Browsers treat all child Nodes of <title> tags as Text content and React expects to be able to convert `children` of <title> tags to a single string value' +
+            ' which is why Arrays of length greater than 1 are not supported. When using JSX it can be common to combine text nodes and value nodes.' +
+            ' For example: <title>hello {nameOfUser}</title>. While not immediately apparent, `children` in this case is an Array with length 2. If your `children` prop' +
+            ' is using this form try rewriting it using a template string: <title>{`hello ${nameOfUser}`}</title>.',
+          children.length,
+        );
+      } else if (typeof child === 'function' || typeof child === 'symbol') {
+        const childType =
+          typeof child === 'function' ? 'a Function' : 'a Symbol';
+        console.error(
+          'React expect children of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found %s instead.' +
+            ' Browsers treat all child Nodes of <title> tags as Text content and React expects to be able to convert children of <title>' +
+            ' tags to a single string value.',
+          childType,
+        );
+        // $FlowFixMe[invalid-compare]
+        // $FlowFixMe[constant-condition]
+      } else if (child && child.toString === {}.toString) {
+        if (child.$$typeof != null) {
+          console.error(
+            'React expects the `children` prop of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found an object that appears to be' +
+              ' a React element which never implements a suitable `toString` method. Browsers treat all child Nodes of <title> tags as Text content and React expects to' +
+              ' be able to convert children of <title> tags to a single string value which is why rendering React elements is not supported. If the `children` of <title> is' +
+              ' a React Component try moving the <title> tag into that component. If the `children` of <title> is some HTML markup change it to be Text only to be valid HTML.',
+          );
+        } else {
+          console.error(
+            'React expects the `children` prop of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found an object that does not implement' +
+              ' a suitable `toString` method. Browsers treat all child Nodes of <title> tags as Text content and React expects to be able to convert children of <title> tags' +
+              ' to a single string value. Using the default `toString` method available on every object is almost certainly an error. Consider whether the `children` of this <title>' +
+              ' is an object in error and change it to a string or number value if so. Otherwise implement a `toString` method that React can use to produce a valid <title>.',
+          );
+        }
+      }
+    }
+  }
+}

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -3740,6 +3740,34 @@ describe('ReactDOMComponent', () => {
     });
   });
 
+  describe('title children', () => {
+    it('should warn if you render a <title> with multiple children', async () => {
+      const container = document.createElement('div');
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => {
+        root.render(
+          <title>
+            {'first'}
+            {'second'}
+          </title>,
+        );
+      });
+      assertConsoleErrorDev([
+        'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
+          'or object with a novel `toString` method but found an Array with length 2 instead. ' +
+          'Browsers treat all child Nodes of <title> tags as Text content and React expects ' +
+          'to be able to convert `children` of <title> tags to a single string value which is why ' +
+          'Arrays of length greater than 1 are not supported. ' +
+          'When using JSX it can be common to combine text nodes and value nodes. ' +
+          'For example: <title>hello {nameOfUser}</title>. ' +
+          'While not immediately apparent, `children` in this case is an Array with length 2. ' +
+          'If your `children` prop is using this form try rewriting it using a template string: ' +
+          '<title>{`hello ${nameOfUser}`}</title>.\n' +
+          '    in title (at **)',
+      ]);
+    });
+  });
+
   // These tests mostly verify the existing behavior.
   // It may not always makes sense but we can't change it in minors.
   describe('Custom elements', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -6091,6 +6091,7 @@ describe('ReactDOMFizzServer', () => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
+      // Server error
       assertConsoleErrorDev([
         'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
           'or object with a novel `toString` method but found an Array with length 2 instead. ' +
@@ -6117,6 +6118,22 @@ describe('ReactDOMFizzServer', () => {
       expect(errors).toEqual([]);
       // with float, the title doesn't render on the client or on the server
       expect(getVisibleChildren(document.head)).toEqual(<title />);
+      // Client error
+      assertConsoleErrorDev(
+        [
+          'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
+            'or object with a novel `toString` method but found an Array with length 2 instead. ' +
+            'Browsers treat all child Nodes of <title> tags as Text content and React expects ' +
+            'to be able to convert `children` of <title> tags to a single string value which is why ' +
+            'Arrays of length greater than 1 are not supported. ' +
+            'When using JSX it can be common to combine text nodes and value nodes. ' +
+            'For example: <title>hello {nameOfUser}</title>. ' +
+            'While not immediately apparent, `children` in this case is an Array with length 2. ' +
+            'If your `children` prop is using this form try rewriting it using a template string: ' +
+            '<title>{`hello ${nameOfUser}`}</title>.',
+        ],
+        {withoutStack: true},
+      );
     });
 
     it('should warn in dev if you pass a React Component as a child to <title>', async () => {
@@ -6138,6 +6155,7 @@ describe('ReactDOMFizzServer', () => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
+      // Server error
       assertConsoleErrorDev([
         'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
           'or object with a novel `toString` method but found an object that appears to be a ' +
@@ -6166,6 +6184,20 @@ describe('ReactDOMFizzServer', () => {
       expect(getVisibleChildren(document.head)).toEqual(
         <title>{'[object Object]'}</title>,
       );
+      // Client error
+      assertConsoleErrorDev(
+        [
+          'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
+            'or object with a novel `toString` method but found an object that appears to be a ' +
+            'React element which never implements a suitable `toString` method. ' +
+            'Browsers treat all child Nodes of <title> tags as Text content and React expects ' +
+            'to be able to convert children of <title> tags to a single string value which is ' +
+            'why rendering React elements is not supported. If the `children` of <title> is a ' +
+            'React Component try moving the <title> tag into that component. ' +
+            'If the `children` of <title> is some HTML markup change it to be Text only to be valid HTML.',
+        ],
+        {withoutStack: true},
+      );
     });
 
     it('should warn in dev if you pass an object that does not implement toString as a child to <title>', async () => {
@@ -6181,6 +6213,7 @@ describe('ReactDOMFizzServer', () => {
         const {pipe} = renderToPipeableStream(<App />);
         pipe(writable);
       });
+      // Server error
       assertConsoleErrorDev([
         'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
           'or object with a novel `toString` method but found an object that does not implement a ' +
@@ -6208,6 +6241,20 @@ describe('ReactDOMFizzServer', () => {
       // object titles are toStringed when float is on
       expect(getVisibleChildren(document.head)).toEqual(
         <title>{'[object Object]'}</title>,
+      );
+      // Client error
+      assertConsoleErrorDev(
+        [
+          'React expects the `children` prop of <title> tags to be a string, number, bigint, ' +
+            'or object with a novel `toString` method but found an object that does not implement a ' +
+            'suitable `toString` method. Browsers treat all child Nodes of <title> tags as Text ' +
+            'content and React expects to be able to convert children of <title> tags to a single string value. ' +
+            'Using the default `toString` method available on every object is almost certainly an error. ' +
+            'Consider whether the `children` of this <title> is an object in error and change it to a ' +
+            'string or number value if so. Otherwise implement a `toString` method that React can ' +
+            'use to produce a valid <title>.',
+        ],
+        {withoutStack: true},
       );
     });
   });


### PR DESCRIPTION
## Summary

`<title>` with multiple JSX children (e.g. `<title>{name} | Projects</title>`) is documented to produce an empty title. SSR already warned about this; the client did not, so the failure was silent in the browser.

This change extracts the existing SSR `<title>` children validation into a shared helper (`ReactDOMTitle.js`) and runs it from client DEV property validation (`setInitialProperties` / `updateProperties`), including hoistable titles. Behavior is unchanged: children are not concatenated. Also fixes the typo `a Sybmol` → `a Symbol` in the shared warning text.

## Test plan

- [x] `yarn test ReactDOMComponent-test --testNamePattern="title children"`
- [x] `yarn test ReactDOMFizzServer-test --testNamePattern="title children"`
- [ ] Confirm client DEV warning when rendering `<title>{projectName} | Projects</title>`
- [ ] Confirm single-string children (e.g. `<title>{`${projectName} | Projects`}</title>`) still work with no warning

Fixes #33341