### PR TITLE
Fix broken links in release and sprout READMEs

### DIFF
--- a/compiler/packages/snap/src/sprout/README.md
+++ b/compiler/packages/snap/src/sprout/README.md
@@ -4,7 +4,7 @@ React Forget test framework that executes compiler fixtures.
 Currently, Sprout runs each fixture with a known set of inputs and annotations. Sprout compares execution outputs (i.e. return values and console logs) of original source code and the corresponding Forget-transformed version.
 We hope to add fuzzing capabilities to Sprout, synthesizing sets of program inputs based on type and/or effect annotations.
 
-Sprout is now enabled for all fixtures! If Sprout cannot execute your fixture due to some technical limitations, add your fixture to [`SproutTodoFilter.ts`](./src/SproutTodoFilter.ts) with a comment explaining why.
+Sprout is now enabled for all fixtures! If Sprout cannot execute your fixture due to some technical limitations, add your fixture to [`SproutTodoFilter.ts`](../SproutTodoFilter.ts) with a comment explaining why.
 
 ### Sprout CLI
 Sprout is now run as a part of snap, except when in filter mode.
@@ -68,7 +68,7 @@ function customHelper(val1, val2) {
 
 - Sprout currently runs each fixture in an iife to prevent variable collisions, but it does not run fixtures in isolation. Please do not mutate any external state in fixtures.
 
-- Sprout does not run fixtures listed in [`SproutTodoFilter.ts`](./src/SproutTodoFilter.ts), even in filter mode.
+- Sprout does not run fixtures listed in [`SproutTodoFilter.ts`](../SproutTodoFilter.ts), even in filter mode.
 
 ### Milestones:
 - [✅] Render fixtures with React runtime / `testing-library/react`.

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -54,7 +54,7 @@ Before promoting, make sure the versions have been bumped:
 1. `package.json` files for each package
 1. [packages/shared/ReactVersion.js](../../packages/shared/ReactVersion.js)
 
-Once the "canary" release has been tested and verified, you can promote it to stable by running the [Publish release](./actions/workflows/runtime_release_from_ci.yml) GitHub Action workflow. This workflow will prepare the release artifacts and publish them to NPM as either `stable-latest` (e.g. for `react@latest`) or `stable-backport` for an older release line that shouldn't move `@latest` (published under the `@backport` dist-tag instead).
+Once the "canary" release has been tested and verified, you can promote it to stable by running the [Publish release](https://github.com/facebook/react/actions/workflows/runtime_release_from_ci.yml) GitHub Action workflow. This workflow will prepare the release artifacts and publish them to NPM as either `stable-latest` (e.g. for `react@latest`) or `stable-backport` for an older release line that shouldn't move `@latest` (published under the `@backport` dist-tag instead).
 
 > [!IMPORTANT]
 > The designated commit must be able to build in CI. If runtime_build_and_test.yml fails for that commit, the release workflow will also fail.
@@ -67,7 +67,7 @@ Once the "canary" release has been tested and verified, you can promote it to st
 1. Make sure versions (`ReactVersions.js`, `ReactVersion.js`, `package.json`) are set to an unreleased version 
 1. Cherry-pick desired commits
 1. Push to branch
-1. [Publish release](./actions/workflows/runtime_release_from_ci.yml)
+1. [Publish release](https://github.com/facebook/react/actions/workflows/runtime_release_from_ci.yml)
    - `workflow_from` is the newly pushed commit containing cherry-picked changes,
    - `type` is either `stable-latest` (e.g. for `react@latest`) or `stable-backport` for an older release line that shouldn't move `@latest` (published under the `@backport` dist-tag instead).
 1. For stable releases the workflow will prepare everything for an automated publish. However, the final publish step will require manual approval in the GitHub Actions UI.


### PR DESCRIPTION
## Summary

Two READMEs contain links that 404 on GitHub:

- `scripts/release/README.md` links the "Publish release" workflow as `./actions/workflows/runtime_release_from_ci.yml` (2 occurrences), which resolves to `scripts/release/actions/...` — a path that doesn't exist. The text intends the GitHub Actions workflow page, so the link now points at `https://github.com/facebook/react/actions/workflows/runtime_release_from_ci.yml` (workflow file verified present at `.github/workflows/runtime_release_from_ci.yml`).
- `compiler/packages/snap/src/sprout/README.md` links `./src/SproutTodoFilter.ts` (2 occurrences), but the README already lives in `src/sprout/`; the file is one directory up at `compiler/packages/snap/src/SproutTodoFilter.ts` → `../SproutTodoFilter.ts`.

## How did you test this change?

Docs-only. Verified each new target exists in the repo (and the workflow file for the Actions URL). A mechanical link audit that resolves every relative markdown link against the filesystem reports these as the only broken README links outside historical CHANGELOG entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)