### PR TITLE
[react-server-dom-turbopack] Support Turbopack's experimental array format for chunks

### DIFF
--- a/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopack.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopack.js
@@ -263,8 +263,9 @@ export function getModuleDebugInfo<T>(
   const debugInfo: ReactDebugInfo = [];
   let i = 0;
   while (i < chunks.length) {
-    const chunkFilename = chunks[i++];
-    addChunkDebugInfo(debugInfo, chunkFilename);
+    const chunk = chunks[i++];
+    // A merged chunk is `[mergedChunkFilename, ...]`; use its own filename.
+    addChunkDebugInfo(debugInfo, typeof chunk === 'string' ? chunk : chunk[0]);
   }
   return debugInfo;
 }

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopackBrowser.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopackBrowser.js
@@ -13,7 +13,9 @@ import type {
   ReactAsyncInfo,
 } from 'shared/ReactTypes';
 
-export function loadChunk(filename: string): Promise<mixed> {
+import type {Chunk} from '../shared/ReactFlightImportMetadata';
+
+export function loadChunk(filename: Chunk): Promise<mixed> {
   return __turbopack_load_by_url__(filename);
 }
 

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopackServer.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopackServer.js
@@ -9,7 +9,9 @@
 
 import type {ReactDebugInfo} from 'shared/ReactTypes';
 
-export function loadChunk(filename: string): Promise<mixed> {
+import type {Chunk} from '../shared/ReactFlightImportMetadata';
+
+export function loadChunk(filename: Chunk): Promise<mixed> {
   return __turbopack_load_by_url__(filename);
 }
 

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigTargetTurbopackServer.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigTargetTurbopackServer.js
@@ -9,6 +9,8 @@
 
 import {preinitScriptForSSR} from 'react-client/src/ReactFlightClientConfig';
 
+import type {Chunk} from '../shared/ReactFlightImportMetadata';
+
 export type ModuleLoading = null | {
   prefix: string,
   crossOrigin?: 'use-credentials' | '',
@@ -16,16 +18,15 @@ export type ModuleLoading = null | {
 
 export function prepareDestinationWithChunks(
   moduleLoading: ModuleLoading,
-  // A chunk is either a single-indexed filename, or a merged chunk emitted as
-  // `[mergedChunkUrl, componentChunkPaths, componentChunkSizes]`.
-  chunks: Array<string | [string, Array<string>, Array<number>]>,
+  chunks: Array<Chunk>,
   nonce: ?string,
 ) {
   if (moduleLoading !== null) {
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i];
+      // A merged chunk is `[mergedChunkFilename, ...]`; preinit its own URL.
       preinitScriptForSSR(
-        moduleLoading.prefix + (Array.isArray(chunk) ? chunk[0] : chunk),
+        moduleLoading.prefix + (typeof chunk === 'string' ? chunk : chunk[0]),
         nonce,
         moduleLoading.crossOrigin,
       );

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigTargetTurbopackServer.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigTargetTurbopackServer.js
@@ -16,14 +16,16 @@ export type ModuleLoading = null | {
 
 export function prepareDestinationWithChunks(
   moduleLoading: ModuleLoading,
-  // Chunks are single-indexed filenames
-  chunks: Array<string>,
+  // A chunk is either a single-indexed filename, or a merged chunk emitted as
+  // `[mergedChunkUrl, componentChunkPaths, componentChunkSizes]`.
+  chunks: Array<string | [string, Array<string>, Array<number>]>,
   nonce: ?string,
 ) {
   if (moduleLoading !== null) {
     for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
       preinitScriptForSSR(
-        moduleLoading.prefix + chunks[i],
+        moduleLoading.prefix + (Array.isArray(chunk) ? chunk[0] : chunk),
         nonce,
         moduleLoading.crossOrigin,
       );

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigTargetTurbopackServer.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigTargetTurbopackServer.js
@@ -25,7 +25,7 @@ export function prepareDestinationWithChunks(
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i];
       preinitScriptForSSR(
-        moduleLoading.prefix + (Array.isArray(chunk) ? chunk[0] : chunk),
+        moduleLoading.prefix + (typeof chunk === 'string' ? chunk : chunk[0]),
         nonce,
         moduleLoading.crossOrigin,
       );

--- a/packages/react-server-dom-turbopack/src/shared/ReactFlightImportMetadata.js
+++ b/packages/react-server-dom-turbopack/src/shared/ReactFlightImportMetadata.js
@@ -7,10 +7,20 @@
  * @flow
  */
 
+// A chunk is either a plain chunk filename, or a merged chunk that bundles
+// several component chunks together, emitted as
+// `[mergedChunkFilename, componentChunkFilenames, componentChunkSizes]`.
+export type Chunk =
+  | string
+  | [
+      /* merged chunk filename */ string,
+      /* component chunk filenames */ Array<string>,
+      /* component chunk sizes */ Array<number>,
+    ];
+
 export type ImportManifestEntry = {
   id: string,
-  // chunks is an array of filenames
-  chunks: Array<string>,
+  chunks: Array<Chunk>,
   name: string,
   async?: boolean,
 };
@@ -20,11 +30,11 @@ export type ImportManifestEntry = {
 export type ImportMetadata =
   | [
       /* id */ string,
-      /* chunk filenames */ Array<string>,
+      /* chunks */ Array<Chunk>,
       /* name */ string,
       /* async */ 1,
     ]
-  | [/* id */ string, /* chunk filenames */ Array<string>, /* name */ string];
+  | [/* id */ string, /* chunks */ Array<Chunk>, /* name */ string];
 
 export const ID = 0;
 export const CHUNKS = 1;

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -146,7 +146,11 @@ declare const __webpack_require__: ((id: string) => any) & {
   u: string => string,
 };
 
-declare function __turbopack_load_by_url__(id: string): Promise<mixed>;
+// A chunk id is a plain filename, or a merged chunk emitted as
+// `[mergedChunkFilename, componentChunkFilenames, componentChunkSizes]`.
+declare function __turbopack_load_by_url__(
+  id: string | [string, Array<string>, Array<number>],
+): Promise<mixed>;
 declare const __turbopack_require__: ((id: string) => any) & {
   u: string => string,
 };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Turbopack has introduced a new format for chunks (experimental):

```typescript
type ChunkUrlOrMerged = ChunkUrl | [ChunkUrl, ChunkPath[], number[]]
```

This will allow us to dynamically choose to merge / unmerge chunks based on already loaded chunks. See https://github.com/vercel/next.js/pull/95261 for more context behind these feature.

However, we noticed that this breaks `prepareDestinationWithChunks()` on server-side renders. The prepared chunk script tags were a stringified version of this array:

<img width="1758" height="474" alt="Screenshot 2026-07-22 at 9 37 06 am" src="https://github.com/user-attachments/assets/fa273b44-5942-4037-b955-4338472242fe" />

Instead, we should prepare the merged chunk as these SSR-d pages would not have any loaded chunks tracked in memory (that happens on the client).

This PR brings back this optimisation and also would remove the console-logged errors associated with them.

## How did you test this change?

I patched my local version of React and ran a Turbopack end-to-end test that tested whether or not we still making requests to these incorrect URLs. We aren't after this change.
