### PR TITLE
Bug: 19.2 batched Suspense reveal can consume the wrong completion segment when a resumed (PPR) stream reuses a queued segment id — DOM corruption + hydration failure

### DIFF
--- a/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetShared.js
+++ b/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetShared.js
@@ -429,6 +429,10 @@ export function completeBoundary(suspenseBoundaryID, contentID) {
     return;
   }
 
+  // Clear the segment id so it cannot collide with future segment ids before
+  // the deferred reveal flush occurs.
+  contentNodeOuter.removeAttribute('id');
+
   // Mark this Suspense boundary as queued so we know not to client render it
   // at the end of document load.
   const suspenseNodeOuter = suspenseIdNodeOuter.previousSibling;


### PR DESCRIPTION
Clear the id attribute of queued boundary content segments in `completeBoundary` (`$RC`) when queuing them into `$RB`. This prevents subsequent `$RS` calls from retrieving the wrong (queued) segment when a resumed PPR stream reuses segment IDs.

---
Fixes #37078

_This PR was drafted by an AI coding agent and reviewed by a human before submission. The code was not executed or tested — please review carefully._