### PR TITLE
fix(devtools): keep filtered commit selection valid across roots

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/profilerContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilerContext-test.js
@@ -854,6 +854,68 @@ describe('ProfilerContext', () => {
     expect(context.selectedCommitIndex).toBe(0);
   });
 
+  it('should select the first visible commit when switching roots with filtering enabled', async () => {
+    const Scheduler = require('scheduler');
+
+    const TimedWork = ({duration}) => {
+      Scheduler.unstable_advanceTime(duration);
+      return null;
+    };
+
+    const containerA = document.createElement('div');
+    const containerB = document.createElement('div');
+
+    const rootA = ReactDOMClient.createRoot(containerA);
+    const rootB = ReactDOMClient.createRoot(containerB);
+
+    utils.act(() => rootA.render(<TimedWork duration={0} />));
+    utils.act(() => rootB.render(<TimedWork duration={0} />));
+
+    await utils.actAsync(() => store.profilerStore.startProfiling());
+    await utils.actAsync(() => rootA.render(<TimedWork duration={200} />));
+    await utils.actAsync(() => rootB.render(<TimedWork duration={1} />));
+    await utils.actAsync(() => rootB.render(<TimedWork duration={100} />));
+    await utils.actAsync(() => store.profilerStore.stopProfiling());
+
+    let context: Context = ((null: any): Context);
+    function ContextReader() {
+      context = React.useContext(ProfilerContext);
+      return null;
+    }
+
+    await utils.actAsync(() =>
+      TestRenderer.create(
+        <Contexts>
+          <ContextReader />
+        </Contexts>,
+      ),
+    );
+
+    const rootIDs = Array.from(context.profilingData.dataForRoots.keys());
+    const [rootAID, rootBID] = rootIDs;
+    const rootBData = context.profilingData.dataForRoots.get(rootBID);
+    const [firstCommit, secondCommit] = rootBData.commitData;
+    const filterThreshold = (firstCommit.duration + secondCommit.duration) / 2;
+
+    await utils.actAsync(() => context.setRootID(rootAID));
+    await utils.actAsync(() => context.setMinCommitDuration(filterThreshold));
+    await utils.actAsync(() => context.setIsCommitFilterEnabled(true));
+    await utils.actAsync(() => context.setRootID(rootBID));
+
+    const filteredCommitIndices = context.filteredCommitIndices;
+    const selectedCommitIndex = context.selectedCommitIndex;
+    const selectedFilteredCommitIndex = context.selectedFilteredCommitIndex;
+
+    await utils.actAsync(() => {
+      context.setMinCommitDuration(0);
+      context.setIsCommitFilterEnabled(false);
+    });
+
+    expect(filteredCommitIndices).toEqual([1]);
+    expect(selectedCommitIndex).toBe(1);
+    expect(selectedFilteredCommitIndex).toBe(0);
+  });
+
   it('should handle commit selection edge cases when filtering commits', async () => {
     const Scheduler = require('scheduler');
 

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/useCommitFilteringAndNavigation.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/useCommitFilteringAndNavigation.js
@@ -40,19 +40,6 @@ export function useCommitFilteringAndNavigation(
   const [minCommitDuration, setMinCommitDurationValue] =
     useLocalStorage<number>('minCommitDuration', 0);
 
-  // Currently selected commit index (in the unfiltered list)
-  const [selectedCommitIndex, selectCommitIndex] = useState<number | null>(
-    null,
-  );
-
-  // Reset commit index when commitData changes (e.g., when switching roots).
-  const [previousCommitData, setPreviousCommitData] =
-    useState<Array<CommitDataFrontend>>(commitData);
-  if (previousCommitData !== commitData) {
-    setPreviousCommitData(commitData);
-    selectCommitIndex(commitData.length > 0 ? 0 : null);
-  }
-
   const calculateFilteredIndices = useCallback(
     (enabled: boolean, minDuration: number): Array<number> => {
       return commitData.reduce((reduced: Array<number>, commitDatum, index) => {
@@ -64,6 +51,26 @@ export function useCommitFilteringAndNavigation(
     },
     [commitData],
   );
+
+  const filteredCommitIndices = useMemo(
+    () => calculateFilteredIndices(isCommitFilterEnabled, minCommitDuration),
+    [calculateFilteredIndices, isCommitFilterEnabled, minCommitDuration],
+  );
+
+  // Currently selected commit index (in the unfiltered list)
+  const [selectedCommitIndex, selectCommitIndex] = useState<number | null>(
+    null,
+  );
+
+  // Reset to the first commit that passes the active filter when commit data changes.
+  const [previousCommitData, setPreviousCommitData] =
+    useState<Array<CommitDataFrontend>>(commitData);
+  if (previousCommitData !== commitData) {
+    setPreviousCommitData(commitData);
+    selectCommitIndex(
+      filteredCommitIndices.length > 0 ? filteredCommitIndices[0] : null,
+    );
+  }
 
   const findFilteredIndex = useCallback(
     (commitIndex: number | null, filtered: Array<number>): number | null => {
@@ -113,11 +120,6 @@ export function useCommitFilteringAndNavigation(
       // Otherwise, the current selection is still valid in the filtered list, keep it
     },
     [findFilteredIndex, selectedCommitIndex, selectCommitIndex],
-  );
-
-  const filteredCommitIndices = useMemo(
-    () => calculateFilteredIndices(isCommitFilterEnabled, minCommitDuration),
-    [calculateFilteredIndices, isCommitFilterEnabled, minCommitDuration],
   );
 
   const selectedFilteredCommitIndex = useMemo(


### PR DESCRIPTION
## Summary

When the selected Profiler root changed, commit navigation always reset to commit index `0`. If the active duration filter excluded that commit, the Profiler kept a hidden commit selected and navigation stopped because no filtered index matched the selection.

- Calculate the filtered commit indices before resetting selection for new root data.
- Select the first commit that passes the active filter, or clear the selection when no commit passes.
- Add regression coverage for switching to a root whose first commit is filtered out.

## How did you test this change?

- `yarn build-for-devtools`
- `node ./scripts/jest/jest-cli.js --build --project devtools --release-channel experimental profilerContext --runInBand --testNamePattern "switching to a different root|switching roots with filtering enabled|selection edge cases when filtering commits"`
  - 1 suite passed, 3 tests passed.
- `node ./scripts/tasks/eslint.js`
- `node ./scripts/tasks/linc.js`
- `flow.cmd status --strip-root`
  - No errors.
- `node ./scripts/prettier/index.js check-changed`
