### PR TITLE
Guard window.event reads on Scheduler task entry in DEV

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -807,16 +807,18 @@ export function shouldAttemptEagerTransition(): boolean {
 
 let schedulerEvent: void | Event = undefined;
 export function trackSchedulerEvent(): void {
-  schedulerEvent = window.event;
+  // Scheduler tasks can run after a test environment tears down `window`
+  // (e.g. per-file jsdom in Jest/Vitest). Profiling attribution is best-effort.
+  schedulerEvent = typeof window !== 'undefined' ? window.event : undefined;
 }
 
 export function resolveEventType(): null | string {
-  const event = window.event;
+  const event = typeof window !== 'undefined' ? window.event : undefined;
   return event && event !== schedulerEvent ? event.type : null;
 }
 
 export function resolveEventTimeStamp(): number {
-  const event = window.event;
+  const event = typeof window !== 'undefined' ? window.event : undefined;
   return event && event !== schedulerEvent ? event.timeStamp : -1.1;
 }
 

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -444,4 +444,27 @@ describe('ReactDOMRoot', () => {
         '  root.render(Symbol(foo))',
     ]);
   });
+
+  // @gate enableComponentPerformanceTrack
+  it('does not throw when a scheduled task runs after window is torn down', async () => {
+    // Regression for #37100: DEV Performance Tracks attribution reads
+    // window.event at the entry of Scheduler tasks. Test runners that tear
+    // down per-file DOM environments can delete `window` while a task is still
+    // queued; that read must not crash the process.
+    const root = ReactDOMClient.createRoot(container);
+    root.render(<div>hello</div>);
+
+    const savedWindow = global.window;
+    const savedDocument = global.document;
+    try {
+      delete global.window;
+      delete global.document;
+      await waitForAll([]);
+    } finally {
+      global.window = savedWindow;
+      global.document = savedDocument;
+    }
+
+    expect(container.textContent).toBe('hello');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #37100.

In DEV builds, Performance Tracks attribution reads `window.event` at the
entry of Scheduler-driven tasks (`trackSchedulerEvent`, and the related
`resolveEventType` / `resolveEventTimeStamp` helpers). Those tasks can
still be queued when a test runner tears down a per-file jsdom/happy-dom
environment and deletes `window`, which throws `ReferenceError: window is
not defined` and fails the suite even though every test passed.

This change typeof-guards those reads so attribution resolves to
`undefined` when `window` is gone, matching existing react-dom patterns
for host globals that may be absent outside a live browser DOM.

## Test plan

- [x] Added regression test: scheduled render after `window`/`document`
      teardown does not throw (`ReactDOMRoot-test`)
- [x] `yarn test ReactDOMRoot-test --dev -r=experimental` — all passing
- [x] Reproduced the crash with the issue’s Node + jsdom script against
      stock 19.2.x; confirmed the guarded path exits cleanly