### PR TITLE
[Flight] Make fake stack frame URLs reversible 

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -95,6 +95,7 @@ import {
 import getComponentNameFromType from 'shared/getComponentNameFromType';
 
 import {getOwnerStackByComponentInfoInDev} from 'shared/ReactComponentInfoStack';
+import {makeVirtualSourceURL} from 'shared/ReactFlightVirtualSourceURL';
 
 import hasOwnProperty from 'shared/hasOwnProperty';
 
@@ -3800,29 +3801,10 @@ function createFakeFunction<T>(
     code = comment + code;
   }
 
-  if (filename.startsWith('/')) {
-    // If the filename starts with `/` we assume that it is a file system file
-    // rather than relative to the current host. Since on the server fully qualified
-    // stack traces use the file path.
-    // TODO: What does this look like on Windows?
-    filename = 'file://' + filename;
-  }
-
   if (sourceMap) {
-    // We use the prefix about://React/ to separate these from other files listed in
-    // the Chrome DevTools. We need a "host name" and not just a protocol because
-    // otherwise the group name becomes the root folder. Ideally we don't want to
-    // show these at all but there's two reasons to assign a fake URL.
-    // 1) A printed stack trace string needs a unique URL to be able to source map it.
-    // 2) If source maps are disabled or fails, you should at least be able to tell
-    //    which file it was.
     code +=
-      '\n//# sourceURL=about://React/' +
-      encodeURIComponent(environmentName) +
-      '/' +
-      encodeURI(filename) +
-      '?' +
-      fakeFunctionIdx++;
+      '\n//# sourceURL=' +
+      makeVirtualSourceURL(environmentName, filename, '' + fakeFunctionIdx++);
     code += '\n//# sourceMappingURL=' + sourceMap;
   } else if (filename) {
     code += '\n//# sourceURL=' + encodeURI(filename);

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -364,6 +364,7 @@ type Response = {
   _debugEndTime: null | number, // DEV-only
   _debugIOStarted: boolean, // DEV-only
   _debugFindSourceMapURL?: void | FindSourceMapURLCallback, // DEV-only
+  _debugFakeFunctionCache?: Map<string, FakeFunction<any>>, // DEV-only
   _debugChannel?: void | DebugChannel, // DEV-only
   _blockedConsole?: null | SomeChunk<ConsoleEntry>, // DEV-only
   _replayConsole: boolean, // DEV-only
@@ -2789,6 +2790,7 @@ function ResponseInstance(
     }
     this._debugEndTime = debugEndTime === undefined ? null : debugEndTime;
     this._debugFindSourceMapURL = findSourceMapURL;
+    this._debugFakeFunctionCache = new Map();
     this._debugChannel = debugChannel;
     this._blockedConsole = null;
     this._replayConsole = replayConsole;
@@ -3673,9 +3675,6 @@ function resolveHint<Code: HintCode>(
 const supportsCreateTask = __DEV__ && !!(console as any).createTask;
 
 type FakeFunction<T> = (() => T) => T;
-const fakeFunctionCache: Map<string, FakeFunction<any>> = __DEV__
-  ? new Map()
-  : (null as any);
 
 let fakeFunctionIdx = 0;
 function createFakeFunction<T>(
@@ -3869,7 +3868,13 @@ function buildFakeCallStack<T>(
       '-' +
       environmentName +
       (useEnclosingLine ? '-e' : '-n');
-    let fn = fakeFunctionCache.get(frameKey);
+    // The cache lives on the response since the _debugFindSourceMapURL
+    // function is an input and can vary by response.
+    const fakeFunctionCache = response._debugFakeFunctionCache;
+    let fn =
+      fakeFunctionCache !== undefined
+        ? fakeFunctionCache.get(frameKey)
+        : undefined;
     if (fn === undefined) {
       const [name, filename, line, col, enclosingLine, enclosingCol] = frame;
       const findSourceMapURL = response._debugFindSourceMapURL;
@@ -3886,9 +3891,9 @@ function buildFakeCallStack<T>(
         useEnclosingLine ? col : enclosingCol,
         environmentName,
       );
-      // TODO: This cache should technically live on the response since the _debugFindSourceMapURL
-      // function is an input and can vary by response.
-      fakeFunctionCache.set(frameKey, fn);
+      if (fakeFunctionCache !== undefined) {
+        fakeFunctionCache.set(frameKey, fn);
+      }
     }
     callStack = fn.bind(null, callStack);
   }

--- a/packages/react-client/src/ReactFlightReplyClient.js
+++ b/packages/react-client/src/ReactFlightReplyClient.js
@@ -36,6 +36,7 @@ import {writeTemporaryReference} from './ReactFlightTemporaryReferences';
 
 import isArray from 'shared/isArray';
 import getPrototypeOf from 'shared/getPrototypeOf';
+import {makeVirtualSourceURL} from 'shared/ReactFlightVirtualSourceURL';
 
 const ObjectPrototype = Object.prototype;
 
@@ -1148,29 +1149,15 @@ function createFakeServerFunction<A: Iterable<any>, T>(
       '})';
   }
 
-  if (filename.startsWith('/')) {
-    // If the filename starts with `/` we assume that it is a file system file
-    // rather than relative to the current host. Since on the server fully qualified
-    // stack traces use the file path.
-    // TODO: What does this look like on Windows?
-    filename = 'file://' + filename;
-  }
-
   if (sourceMap) {
-    // We use the prefix about://React/ to separate these from other files listed in
-    // the Chrome DevTools. We need a "host name" and not just a protocol because
-    // otherwise the group name becomes the root folder. Ideally we don't want to
-    // show these at all but there's two reasons to assign a fake URL.
-    // 1) A printed stack trace string needs a unique URL to be able to source map it.
-    // 2) If source maps are disabled or fails, you should at least be able to tell
-    //    which file it was.
     code +=
-      '\n//# sourceURL=about://React/' +
-      encodeURIComponent(environmentName) +
-      '/' +
-      encodeURI(filename) +
-      '?s' + // We add an extra s here to distinguish from the fake stack frames
-      fakeServerFunctionIdx++;
+      '\n//# sourceURL=' +
+      makeVirtualSourceURL(
+        environmentName,
+        filename,
+        // We add an extra s here to distinguish from the fake stack frames
+        's' + fakeServerFunctionIdx++,
+      );
     code += '\n//# sourceMappingURL=' + sourceMap;
   } else if (filename) {
     code += '\n//# sourceURL=' + filename;

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -3520,8 +3520,7 @@ describe('ReactFlight', () => {
       // Test only the first rows since there's a lot of noise after that is eliminated.
       .split('\n')
       .slice(0, 4)
-      .join('\n')
-      .replaceAll(' (/', ' (file:///'); // The eval will end up normalizing these
+      .join('\n');
 
     let sawReactPrefix = false;
     const environments = [];
@@ -3560,6 +3559,149 @@ describe('ReactFlight', () => {
   });
 
   // @gate !__DEV__ || enableComponentPerformanceTrack
+  it('round-trips special-character filenames across server-to-server passes', async () => {
+    async function ServerComponent({transport}) {
+      // This is a Server Component that receives other Server Components from a third party.
+      const thirdParty = ReactServer.use(
+        ReactNoopFlightClient.read(transport, {
+          findSourceMapURL(url) {
+            // By giving a source map url we're saying that we can't use the original
+            // file as the sourceURL, which gives stack traces a about://React/ prefix.
+            // encodeURI because the sourceMappingURL comment ends at whitespace and
+            // some of the filenames below contain spaces.
+            return 'source-map://' + encodeURI(url);
+          },
+        }),
+      );
+      await thirdParty.model;
+      return 'Should never render';
+    }
+
+    const error = new Error('third-party-error');
+    // Fake a stack with filenames that have a special meaning in URLs. The
+    // fake eval:ed frames embed the filename in their virtual sourceURL, so
+    // if the encoding isn't reversed exactly, the next serialization pass
+    // sees a different filename and its source map can no longer be found.
+    error.stack = [
+      'Error: third-party-error',
+      '    at hash (/code/dir#fragment/page.js:10:5)',
+      '    at space (/code/my project/page.js:11:5)',
+      '    at percent (/code/50%off/page.js:12:5)',
+      '    at question (/code/what?/page.js:13:5)',
+      // Sequences that collide with the escaped forms of '#' and '?'.
+      '    at escapedHash (/code/a%23b/page.js:14:5)',
+      '    at escapedQuestion (/code/a%3Fb/page.js:15:5)',
+      '    at unicode (file:///プロジェクト/ページ.js:16:5)',
+    ].join('\n');
+    const rejectedPromise = Promise.reject(error);
+
+    const thirdPartyTransport = ReactNoopFlightServer.render(
+      {model: rejectedPromise},
+      {
+        // The environment name is also embedded in the virtual sourceURL and
+        // a '/' in it must not shift where the filename starts.
+        environmentName: 'third/party',
+        onError(x) {
+          return __DEV__ ? 'a dev digest' : `digest("${x.message}")`;
+        },
+      },
+    );
+
+    await rejectedPromise.catch(() => {});
+
+    const transport = ReactNoopFlightServer.render(
+      <ServerComponent transport={thirdPartyTransport} />,
+      {
+        onError(x) {
+          return __DEV__ ? 'a dev digest' : x.digest;
+        },
+      },
+    );
+
+    await 0;
+    await 0;
+    await 0;
+
+    const errors = [];
+    class MyErrorBoundary extends React.Component {
+      state = {error: null};
+      static getDerivedStateFromError(caughtError) {
+        return {error: caughtError};
+      }
+      componentDidCatch(caughtError, componentInfo) {
+        errors.push(caughtError);
+      }
+      render() {
+        if (this.state.error) {
+          return null;
+        }
+        return this.props.children;
+      }
+    }
+
+    const findSourceMapURL = jest.fn(url => 'source-map://' + encodeURI(url));
+    await act(async () => {
+      ReactNoop.render(
+        <MyErrorBoundary>
+          {ReactNoopFlightClient.read(transport, {findSourceMapURL})}
+        </MyErrorBoundary>,
+      );
+    });
+
+    expect(errors.length).toBe(1);
+    if (__DEV__) {
+      // The filenames must come back in their original form, not in whatever
+      // form the previous pass embedded them in its sourceURLs, so that this
+      // pass can find their source maps. (Other calls happen too, e.g. for
+      // ServerComponent itself.)
+      expect(findSourceMapURL.mock.calls).toEqual(
+        expect.arrayContaining([
+          ['/code/dir#fragment/page.js', 'third/party'],
+          ['/code/my project/page.js', 'third/party'],
+          ['/code/50%off/page.js', 'third/party'],
+          ['/code/what?/page.js', 'third/party'],
+          ['/code/a%23b/page.js', 'third/party'],
+          ['/code/a%3Fb/page.js', 'third/party'],
+          ['file:///プロジェクト/ページ.js', 'third/party'],
+        ]),
+      );
+
+      // In the revived stack, each frame's virtual sourceURL escapes the
+      // filename such that the whole thing stays a well-formed URL: '#' and
+      // '?' would otherwise read as the URL's fragment/query, and a literal
+      // '%23' in a filename has to stay distinct from an escaped '#'. The
+      // trailing '?' is where the unique query that follows the filename
+      // starts.
+      const stack = errors[0].stack;
+      expect(stack).toContain(
+        '(about://React/third%2Fparty//code/dir%23fragment/page.js?',
+      );
+      expect(stack).toContain(
+        '(about://React/third%2Fparty//code/my%20project/page.js?',
+      );
+      expect(stack).toContain(
+        '(about://React/third%2Fparty//code/50%25off/page.js?',
+      );
+      expect(stack).toContain(
+        '(about://React/third%2Fparty//code/what%3F/page.js?',
+      );
+      expect(stack).toContain(
+        '(about://React/third%2Fparty//code/a%2523b/page.js?',
+      );
+      expect(stack).toContain(
+        '(about://React/third%2Fparty//code/a%253Fb/page.js?',
+      );
+      expect(stack).not.toContain('/code/dir#fragment');
+    } else {
+      expect(errors[0].message).toBe(
+        'An error occurred in the Server Components render. The specific message is omitted in production' +
+          ' builds to avoid leaking sensitive details. A digest property is included on this error instance which' +
+          ' may provide additional details about the nature of the error.',
+      );
+      expect(errors[0].digest).toBe('digest("third-party-error")');
+    }
+  });
+
   it('can change the environment name inside a component', async () => {
     let env = 'A';
     function Component(props) {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -982,8 +982,8 @@ describe('ReactFlightDOMNode', () => {
           (gate(flags => flags.enableAsyncDebugInfo)
             ? '\n    at SharedComponent (./ReactFlightDOMNode-test.js:838:7)'
             : '') +
-          '\n    at ServerComponent (file://./ReactFlightDOMNode-test.js:860:26)' +
-          '\n    at App (file://./ReactFlightDOMNode-test.js:877:25)',
+          '\n    at ServerComponent (./ReactFlightDOMNode-test.js:860:26)' +
+          '\n    at App (./ReactFlightDOMNode-test.js:877:25)',
       );
     } else {
       expect(ownerStack).toBeNull();
@@ -1567,11 +1567,11 @@ describe('ReactFlightDOMNode', () => {
           '\n' +
             '    in Dynamic' +
             (gate(flags => flags.enableAsyncDebugInfo)
-              ? ' (file://ReactFlightDOMNode-test.js:1441:27)\n'
+              ? ' (ReactFlightDOMNode-test.js:1441:27)\n'
               : '\n') +
             '    in body\n' +
             '    in html\n' +
-            '    in App (file://ReactFlightDOMNode-test.js:1454:25)\n' +
+            '    in App (ReactFlightDOMNode-test.js:1454:25)\n' +
             '    in ClientRoot (ReactFlightDOMNode-test.js:1529:16)',
         );
       } else {
@@ -1591,17 +1591,13 @@ describe('ReactFlightDOMNode', () => {
             normalizeCodeLocInfo(ownerStack, {preserveLocation: true}),
           ).toBe(
             '\n' +
-              '    in Dynamic (file://ReactFlightDOMNode-test.js:1441:27)\n' +
-              '    in App (file://ReactFlightDOMNode-test.js:1454:25)',
+              '    in Dynamic (ReactFlightDOMNode-test.js:1441:27)\n' +
+              '    in App (ReactFlightDOMNode-test.js:1454:25)',
           );
         } else {
           expect(
             normalizeCodeLocInfo(ownerStack, {preserveLocation: true}),
-          ).toBe(
-            '' +
-              '\n' +
-              '    in App (file://ReactFlightDOMNode-test.js:1454:25)',
-          );
+          ).toBe('' + '\n' + '    in App (ReactFlightDOMNode-test.js:1454:25)');
         }
       } else {
         expect(ownerStack).toBeNull();
@@ -1757,7 +1753,7 @@ describe('ReactFlightDOMNode', () => {
           normalizeCodeLocInfo(componentStack, {preserveLocation: true}),
         ).toBe(
           '\n' +
-            '    in ClientDynamic (ReactFlightDOMNode-test.js:1704:9)\n' +
+            '    in ClientDynamic (ReactFlightDOMNode-test.js:1700:9)\n' +
             '    in Suspense\n' +
             '    in body\n' +
             '    in html\n' +
@@ -1768,7 +1764,7 @@ describe('ReactFlightDOMNode', () => {
           normalizeCodeLocInfo(componentStack, {preserveLocation: true}),
         ).toBe(
           '\n' +
-            '    in ClientDynamic (ReactFlightDOMNode-test.js:1704:9)\n' +
+            '    in ClientDynamic (ReactFlightDOMNode-test.js:1700:9)\n' +
             '    in Suspense\n' +
             '    in body\n' +
             '    in html\n' +
@@ -1781,10 +1777,10 @@ describe('ReactFlightDOMNode', () => {
           '\n' +
             gate(flags =>
               flags.enableAsyncDebugInfo
-                ? '    at ClientDynamic (./ReactFlightDOMNode-test.js:1705:9)\n'
+                ? '    at ClientDynamic (./ReactFlightDOMNode-test.js:1701:9)\n'
                 : '',
             ) +
-            '    at ClientRoot (./ReactFlightDOMNode-test.js:1718:21)',
+            '    at ClientRoot (./ReactFlightDOMNode-test.js:1714:21)',
         );
       } else {
         expect(ownerStack).toBeNull();

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -119,6 +119,7 @@ import {resolveOwner, setCurrentOwner} from './flight/ReactFlightCurrentOwner';
 
 import {getOwnerStackByComponentInfoInDev} from 'shared/ReactComponentInfoStack';
 import {resetOwnerStackLimit} from 'shared/ReactOwnerStackReset';
+import {devirtualizeSourceURL} from 'shared/ReactFlightVirtualSourceURL';
 
 import noop from 'shared/noop';
 
@@ -177,21 +178,6 @@ function defaultFilterStackFrame(
     !filename.startsWith('node:') &&
     !filename.includes('node_modules')
   );
-}
-
-function devirtualizeURL(url: string): string {
-  if (url.startsWith('about://React/')) {
-    // This callsite is a virtual fake callsite that came from another Flight client.
-    // We need to reverse it back into the original location by stripping its prefix
-    // and suffix. We don't need the environment name because it's available on the
-    // parent object that will contain the stack.
-    const envIdx = url.indexOf('/', 'about://React/'.length);
-    const suffixIdx = url.lastIndexOf('?');
-    if (envIdx > -1 && suffixIdx > -1) {
-      return decodeURI(url.slice(envIdx + 1, suffixIdx));
-    }
-  }
-  return url;
 }
 
 function isPromiseCreationInternal(url: string, functionName: string): boolean {
@@ -256,7 +242,7 @@ function findCalledFunctionNameFromStackTrace(
   for (let i = 0; i < stack.length; i++) {
     const callsite = stack[i];
     const functionName = callsite[0];
-    const url = devirtualizeURL(callsite[1]);
+    const url = devirtualizeSourceURL(callsite[1]);
     const lineNumber = callsite[2];
     const columnNumber = callsite[3];
     if (
@@ -290,7 +276,7 @@ function filterStackTrace(
   for (let i = 0; i < stack.length; i++) {
     const callsite = stack[i];
     const functionName = callsite[0];
-    const url = devirtualizeURL(callsite[1]);
+    const url = devirtualizeSourceURL(callsite[1]);
     const lineNumber = callsite[2];
     const columnNumber = callsite[3];
     if (filterStackFrame(url, functionName, lineNumber, columnNumber)) {
@@ -309,7 +295,7 @@ function hasUnfilteredFrame(request: Request, stack: ReactStackTrace): boolean {
   for (let i = 0; i < stack.length; i++) {
     const callsite = stack[i];
     const functionName = callsite[0];
-    const url = devirtualizeURL(callsite[1]);
+    const url = devirtualizeSourceURL(callsite[1]);
     const lineNumber = callsite[2];
     const columnNumber = callsite[3];
     // Ignore async stack frames because they're not "real". We'd expect to have at least
@@ -390,7 +376,7 @@ export function isAwaitInUserspace(
     const filterStackFrame = request.filterStackFrame;
     const callsite = stack[firstFrame];
     const functionName = callsite[0];
-    const url = devirtualizeURL(callsite[1]);
+    const url = devirtualizeSourceURL(callsite[1]);
     const lineNumber = callsite[2];
     const columnNumber = callsite[3];
     return (

--- a/packages/shared/ReactFlightVirtualSourceURL.js
+++ b/packages/shared/ReactFlightVirtualSourceURL.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Fake stack frame functions are eval:ed with a virtual sourceURL of the form
+//
+//   about://React/<environmentName>/<filename>?<query>
+//
+// where <query> is a unique index that deduplicates otherwise identical
+// scripts. The filename is an arbitrary string (a file path on the server, a
+// file: URL for ES modules, a webpack-internal: URL, ...) so it is escaped
+// such that it can always be recovered exactly:
+//
+//   devirtualizeVirtualSourceURL(makeVirtualSourceURL(env, filename, query))
+//     === filename
+//
+// for every filename. Frameworks rely on this to map a frame that crossed
+// multiple Flight hops back to the original script (e.g. to look up its
+// source map), so the escaping must stay bijective. It also keeps the whole
+// virtual URL well-formed: a raw '#' or '?' in the filename would otherwise
+// be parsed as the URL's own fragment or query by debugger frontends.
+
+const virtualSourceURLPrefix = 'about://React/';
+
+function escapeFilename(filename: string): string {
+  // encodeURI escapes '%' (and whitespace, which would terminate the
+  // //# sourceURL= comment) but passes '#' and '?' through. Escape those two
+  // as well so the embedded filename contains neither.
+  return encodeURI(filename).replace(/#/g, '%23').replace(/\?/g, '%3F');
+}
+
+function unescapeFilename(escaped: string): string {
+  // Reverse of escapeFilename. The replaces must run before decodeURI: at
+  // this point a literal '%23'/'%3F' in the original filename is still
+  // encoded as '%2523'/'%253F', so these can only match our own escapes.
+  // decodeURI itself never decodes '%23'/'%3F' since '#' and '?' are
+  // reserved characters.
+  return decodeURI(escaped.replace(/%23/g, '#').replace(/%3F/g, '?'));
+}
+
+// We use the prefix about://React/ to separate these from other files listed
+// in the Chrome DevTools. We need a "host name" and not just a protocol
+// because otherwise the group name becomes the root folder. Ideally we don't
+// want to show these at all but there's two reasons to assign a fake URL.
+// 1) A printed stack trace string needs a unique URL to be able to source map it.
+// 2) If source maps are disabled or fails, you should at least be able to tell
+//    which file it was.
+export function makeVirtualSourceURL(
+  environmentName: string,
+  filename: string,
+  query: string,
+): string {
+  return (
+    virtualSourceURLPrefix +
+    encodeURIComponent(environmentName) +
+    '/' +
+    escapeFilename(filename) +
+    '?' +
+    query
+  );
+}
+
+export function devirtualizeSourceURL(url: string): string {
+  if (url.startsWith(virtualSourceURLPrefix)) {
+    // Reverse the URL back into the original filename by stripping the
+    // prefix, the environment name and the query. The environment name isn't
+    // returned because it's available on the parent object that contains the
+    // stack.
+    const envIdx = url.indexOf('/', virtualSourceURLPrefix.length);
+    // escapeFilename never leaves a raw '?' in the filename, so the last '?'
+    // is the one appended by makeVirtualSourceURL.
+    const suffixIdx = url.lastIndexOf('?');
+    if (envIdx > -1 && suffixIdx > -1) {
+      return unescapeFilename(url.slice(envIdx + 1, suffixIdx));
+    }
+  }
+  return url;
+}


### PR DESCRIPTION
Bumped into this while working on https://github.com/vercel/next.js/pull/95944.

Concretely, https://github.com/vercel/next.js/pull/95946#discussion_r3645178159.

## Problem

`createFakeFunction` embeds the frame's filename in the fake function's `sourceURL`:

```
about://React/<environmentName>/<encodeURI('file://' + filename)>?<id>
```

The `'file://' +` is added only when the filename starts with `/`, and that condition makes it irreversible, since it can't be removed symmetrically on deserialization (because we don't know if it was there in the beginning or not).

As a result, if we deal with a stack that passed through another Flight server, we'd *always* get `file://`:

```
devirtualizeURL for a once-transported frame:   /app/chunks/[root-of-the-server]__abc.js
devirtualizeURL for a twice-transported frame:  file:///app/chunks/[root-of-the-server]__abc.js
```

The first string is what V8 reported, so a `findSourceMapURL` implementation can resolve it with host APIs. The second one doesn't match what V8 reported. So if we want to hit the Node.js cache for sourcemaps, we somehow need to figure out the original path in the form like `/app/chunks/[root-of-the-server]__abc.js` so that we can use `pathToFileURL` on it (which is how Node.js keys it). However, if I understand correctly, we can't always just strip `file://` away because ESM frames legitimately *are* `file://`. So the issue is that the roundtrip is lossy.

## Fix

Make virtualize/devirtualize roundtrip lossless.

This means we don't add `file://` anymore (since it adds ambiguity). Filenames now survive any number of round trips, so `findSourceMapURL` sees the same input on every pass, and and consumers can derive Node's cache key reliably with `pathToFileURL` instead of guessing at the percent-encoding.

Filenames are embedded with `encodeURI` plus `#` → `%23` and `?` → `%3F` so the virtual URL stays well-formed and the last `?` is always the id.

Also moves `fakeFunctionCache` onto the response, since `findSourceMapURL` is a per-response. This might need a module-level WeakMap to keep it fast?

## Downstream changes

This would need a corresponding Next.js change to match the new format when devirtualizing.