### PR TITLE
[FlightReply] Avoid unhandled rejections in `decodeReplyFromAsyncIterable`

### DIFF
--- a/packages/react-server-dom-parcel/src/server/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-parcel/src/server/ReactFlightDOMServerEdge.js
@@ -307,7 +307,7 @@ export function decodeReplyFromAsyncIterable<T>(
       } else {
         resolveFile(response, name, value);
       }
-      iterator.next().then(progress, error);
+      iterator.next().then(progress).catch(error);
     }
   }
   function error(reason: Error) {
@@ -319,7 +319,7 @@ export function decodeReplyFromAsyncIterable<T>(
     }
   }
 
-  iterator.next().then(progress, error);
+  iterator.next().then(progress).catch(error);
 
   return getRoot(response);
 }

--- a/packages/react-server-dom-parcel/src/server/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-parcel/src/server/ReactFlightDOMServerNode.js
@@ -765,7 +765,7 @@ export function decodeReplyFromAsyncIterable<T>(
       } else {
         resolveFile(response, name, value);
       }
-      iterator.next().then(progress, error);
+      iterator.next().then(progress).catch(error);
     }
   }
   function error(reason: Error) {
@@ -777,7 +777,7 @@ export function decodeReplyFromAsyncIterable<T>(
     }
   }
 
-  iterator.next().then(progress, error);
+  iterator.next().then(progress).catch(error);
 
   return getRoot(response);
 }

--- a/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerEdge.js
@@ -306,7 +306,7 @@ function decodeReplyFromAsyncIterable<T>(
       } else {
         resolveFile(response, name, value);
       }
-      iterator.next().then(progress, error);
+      iterator.next().then(progress).catch(error);
     }
   }
   function error(reason: Error) {
@@ -318,7 +318,7 @@ function decodeReplyFromAsyncIterable<T>(
     }
   }
 
-  iterator.next().then(progress, error);
+  iterator.next().then(progress).catch(error);
 
   return getRoot(response);
 }

--- a/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerNode.js
@@ -759,7 +759,7 @@ function decodeReplyFromAsyncIterable<T>(
       } else {
         resolveFile(response, name, value);
       }
-      iterator.next().then(progress, error);
+      iterator.next().then(progress).catch(error);
     }
   }
   function error(reason: Error) {
@@ -771,7 +771,7 @@ function decodeReplyFromAsyncIterable<T>(
     }
   }
 
-  iterator.next().then(progress, error);
+  iterator.next().then(progress).catch(error);
 
   return getRoot(response);
 }

--- a/packages/react-server-dom-unbundled/src/server/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-unbundled/src/server/ReactFlightDOMServerNode.js
@@ -759,7 +759,7 @@ function decodeReplyFromAsyncIterable<T>(
       } else {
         resolveFile(response, name, value);
       }
-      iterator.next().then(progress, error);
+      iterator.next().then(progress).catch(error);
     }
   }
   function error(reason: Error) {
@@ -771,7 +771,7 @@ function decodeReplyFromAsyncIterable<T>(
     }
   }
 
-  iterator.next().then(progress, error);
+  iterator.next().then(progress).catch(error);
 
   return getRoot(response);
 }

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReplyEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMReplyEdge-test.js
@@ -45,6 +45,22 @@ describe('ReactFlightDOMReplyEdge', () => {
     expect(decoded).toEqual({some: 'object'});
   });
 
+  it('does not produce unhandled rejections when reading from an inconsistent async iterable', async () => {
+    const iterable = {
+      async *[Symbol.asyncIterator]() {
+        yield ['0', '"hello"'];
+        yield ['0', '"sebbie"'];
+      },
+    };
+
+    const result = await ReactServerDOMServer.decodeReplyFromAsyncIterable(
+      iterable,
+      webpackServerMap,
+    );
+
+    expect(result).toBe('hello');
+  });
+
   it('should be able to serialize any kind of typed array', async () => {
     const buffer = new Uint8Array([
       123, 4, 10, 5, 100, 255, 244, 45, 56, 67, 43, 124, 67, 89, 100, 20,

--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
@@ -306,7 +306,7 @@ function decodeReplyFromAsyncIterable<T>(
       } else {
         resolveFile(response, name, value);
       }
-      iterator.next().then(progress, error);
+      iterator.next().then(progress).catch(error);
     }
   }
   function error(reason: Error) {
@@ -318,7 +318,7 @@ function decodeReplyFromAsyncIterable<T>(
     }
   }
 
-  iterator.next().then(progress, error);
+  iterator.next().then(progress).catch(error);
 
   return getRoot(response);
 }

--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js
@@ -760,7 +760,7 @@ function decodeReplyFromAsyncIterable<T>(
       } else {
         resolveFile(response, name, value);
       }
-      iterator.next().then(progress, error);
+      iterator.next().then(progress).catch(error);
     }
   }
   function error(reason: Error) {
@@ -772,7 +772,7 @@ function decodeReplyFromAsyncIterable<T>(
     }
   }
 
-  iterator.next().then(progress, error);
+  iterator.next().then(progress).catch(error);
 
   return getRoot(response);
 }


### PR DESCRIPTION
FormData that contains fields that are not part of a Reply (e.g. due to missing formPrefix) can leave the reply hanging with an unhandled rejection.

Unhandled rejections should still be handled by the server to avoid crashes.

There are more places where we don't handled rejections from progress. I'm not sure if `.catch` is sound everywhere in case we receive a ReactThenable. Might be better to just wrap progress in try-catch