### PR TITLE
[DevTools] Handle invalid profiler commit indices

### DIFF
--- a/packages/react-devtools-cdt-mcp/src/DevToolsCdtMcp.js
+++ b/packages/react-devtools-cdt-mcp/src/DevToolsCdtMcp.js
@@ -280,7 +280,8 @@ const TOOL_DEFINITIONS: Array<ToolDefinition> = [
       properties: {
         traceName: {type: 'string', description: 'The trace to query.'},
         commitIndex: {
-          type: 'number',
+          type: 'integer',
+          minimum: 0,
           description: 'Zero-based commit index within the trace.',
         },
       },

--- a/packages/react-devtools-cdt-mcp/src/__tests__/DevToolsCdtMcp-test.js
+++ b/packages/react-devtools-cdt-mcp/src/__tests__/DevToolsCdtMcp-test.js
@@ -330,7 +330,11 @@ describe('react-devtools-cdt-mcp', () => {
       type: 'object',
       properties: {
         traceName: {type: 'string', description: expect.any(String)},
-        commitIndex: {type: 'number', description: expect.any(String)},
+        commitIndex: {
+          type: 'integer',
+          minimum: 0,
+          description: expect.any(String),
+        },
       },
       required: ['traceName', 'commitIndex'],
     });

--- a/packages/react-devtools-facade/src/DevToolsFacadeProfilerTools.js
+++ b/packages/react-devtools-facade/src/DevToolsFacadeProfilerTools.js
@@ -301,7 +301,11 @@ export function createProfilerTools(
     if (trace == null) {
       return {error: 'Unknown trace "' + traceName + '"'};
     }
-    if (commitIndex < 0 || commitIndex >= trace.commits.length) {
+    if (
+      !Number.isInteger(commitIndex) ||
+      commitIndex < 0 ||
+      commitIndex >= trace.commits.length
+    ) {
       return {error: 'Commit index out of range'};
     }
     const commit = trace.commits[commitIndex];

--- a/packages/react-devtools-facade/src/__tests__/DevToolsFacade-test.js
+++ b/packages/react-devtools-facade/src/__tests__/DevToolsFacade-test.js
@@ -2107,14 +2107,18 @@ describe('react-devtools-facade', () => {
       });
     });
 
-    it('getCommitReport returns an error for an out-of-range commit index', () => {
+    it('getCommitReport returns an error for an invalid commit index', () => {
+      const root = ReactDOMClient.createRoot(container);
       startProfiling('range-trace');
-      stopProfiling();
-      expect(getCommitReport('range-trace', 5)).toEqual({
-        error: 'Commit index out of range',
+      act(() => {
+        root.render(<div />);
       });
-      expect(getCommitReport('range-trace', -1)).toEqual({
-        error: 'Commit index out of range',
+      stopProfiling();
+
+      [5, -1, 0.5, NaN].forEach(commitIndex => {
+        expect(getCommitReport('range-trace', commitIndex)).toEqual({
+          error: 'Commit index out of range',
+        });
       });
     });
 


### PR DESCRIPTION
## Summary

`getCommitReport` only checked numeric bounds. A fractional or `NaN` index could pass those comparisons, select no commit, and throw while reading `durations`.

This change validates integer indices before accessing the trace, declares `commitIndex` as a non-negative integer in the MCP schema, and adds regression coverage using a trace with an actual commit.

## How did you test this change?

- focused `DevToolsFacade-test.js` and `DevToolsCdtMcp-test.js` cases (2 passed)
- `yarn flow dom-browser`
- `yarn lint` on the four affected files
- `yarn prettier` on the four affected files
