### PR TITLE
[Flight] Define Flight chunk `.then` with `Object.defineProperty`

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -256,7 +256,7 @@ function ReactPromise(status: any, value: any, reason: any) {
 // We subclass Promise.prototype so that we get other methods like .catch
 ReactPromise.prototype = Object.create(Promise.prototype) as any;
 // TODO: This doesn't return a new Promise chain unlike the real .then
-ReactPromise.prototype.then = function <T>(
+function reactPromiseThen<T>(
   this: SomeChunk<T>,
   resolve: (value: T) => mixed,
   reject?: (reason: mixed) => mixed,
@@ -326,7 +326,17 @@ ReactPromise.prototype.then = function <T>(
       }
       break;
   }
-};
+}
+// The shadowing `then` must be defined with `Object.defineProperty` instead of
+// assignment. Assignment would throw when `Promise.prototype` is frozen (e.g.
+// by SES lockdown) because assigning over an inherited non-writable property
+// is rejected (the "override mistake").
+Object.defineProperty(ReactPromise.prototype, 'then', {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+  value: reactPromiseThen,
+});
 
 export type FindSourceMapURLCallback = (
   fileName: string,

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -330,7 +330,7 @@ function reactPromiseThen<T>(
 // The shadowing `then` must be defined with `Object.defineProperty` instead of
 // assignment. Assignment would throw when `Promise.prototype` is frozen (e.g.
 // by SES lockdown) because assigning over an inherited non-writable property
-// is rejected (the "override mistake").
+// is rejected.
 Object.defineProperty(ReactPromise.prototype, 'then', {
   writable: true,
   enumerable: true,

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightNonWritablePromiseThen-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightNonWritablePromiseThen-test.js
@@ -17,11 +17,6 @@ global.ReadableStream =
 global.TextEncoder = require('util').TextEncoder;
 global.TextDecoder = require('util').TextDecoder;
 
-// When Promise.prototype is frozen (e.g. by SES lockdown()), its `then`
-// becomes a non-writable data property. Assigning a shadowing `then` to an
-// object that inherits from Promise.prototype then throws (the "override
-// mistake"), which used to crash react-server-dom-* at module evaluation
-// because the Flight chunk classes subclass Promise this way.
 describe('ReactFlight with a non-writable Promise.prototype.then', () => {
   let originalThen;
 
@@ -40,7 +35,7 @@ describe('ReactFlight with a non-writable Promise.prototype.then', () => {
     Object.defineProperty(Promise.prototype, 'then', originalThen);
   });
 
-  it('can require the Flight server and client', () => {
+  it('can require Server and Client entrypoints', () => {
     patchMessageChannel(require('scheduler'));
     // Simulate the condition resolution
     jest.mock('react', () => require('react/react.react-server'));

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightNonWritablePromiseThen-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightNonWritablePromiseThen-test.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+import {patchMessageChannel} from '../../../../scripts/jest/patchMessageChannel';
+
+// Polyfills for test environment
+global.ReadableStream =
+  require('web-streams-polyfill/ponyfill/es6').ReadableStream;
+global.TextEncoder = require('util').TextEncoder;
+global.TextDecoder = require('util').TextDecoder;
+
+// When Promise.prototype is frozen (e.g. by SES lockdown()), its `then`
+// becomes a non-writable data property. Assigning a shadowing `then` to an
+// object that inherits from Promise.prototype then throws (the "override
+// mistake"), which used to crash react-server-dom-* at module evaluation
+// because the Flight chunk classes subclass Promise this way.
+describe('ReactFlight with a non-writable Promise.prototype.then', () => {
+  let originalThen;
+
+  beforeEach(() => {
+    jest.resetModules();
+    originalThen = Object.getOwnPropertyDescriptor(Promise.prototype, 'then');
+    // eslint-disable-next-line no-extend-native
+    Object.defineProperty(Promise.prototype, 'then', {
+      ...originalThen,
+      writable: false,
+    });
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line no-extend-native
+    Object.defineProperty(Promise.prototype, 'then', originalThen);
+  });
+
+  it('can require the Flight server and client', () => {
+    patchMessageChannel(require('scheduler'));
+    // Simulate the condition resolution
+    jest.mock('react', () => require('react/react.react-server'));
+    jest.mock('react-server-dom-webpack/server', () =>
+      require('react-server-dom-webpack/server.browser'),
+    );
+    require('./utils/WebpackMock');
+    const ReactServerDOMServer = require('react-server-dom-webpack/server');
+    expect(typeof ReactServerDOMServer.decodeReply).toBe('function');
+
+    __unmockReact();
+    jest.resetModules();
+    const ReactServerDOMClient = require('react-server-dom-webpack/client');
+    expect(typeof ReactServerDOMClient.createFromReadableStream).toBe(
+      'function',
+    );
+  });
+});

--- a/packages/react-server/src/ReactFlightReplyServer.js
+++ b/packages/react-server/src/ReactFlightReplyServer.js
@@ -126,7 +126,7 @@ function ReactPromise(status: any, value: any, reason: any) {
 // We subclass Promise.prototype so that we get other methods like .catch
 ReactPromise.prototype = Object.create(Promise.prototype) as any;
 // TODO: This doesn't return a new Promise chain unlike the real .then
-ReactPromise.prototype.then = function <T>(
+function reactPromiseThen<T>(
   this: SomeChunk<T>,
   resolve: (value: T) => mixed,
   reject: ?(reason: mixed) => mixed,
@@ -197,7 +197,17 @@ ReactPromise.prototype.then = function <T>(
       }
       break;
   }
-};
+}
+// The shadowing `then` must be defined with `Object.defineProperty` instead of
+// assignment. Assignment would throw when `Promise.prototype` is frozen (e.g.
+// by SES lockdown) because assigning over an inherited non-writable property
+// is rejected (the "override mistake").
+Object.defineProperty(ReactPromise.prototype, 'then', {
+  writable: true,
+  enumerable: true,
+  configurable: true,
+  value: reactPromiseThen,
+});
 
 const ObjectPrototype = Object.prototype;
 const ArrayPrototype = Array.prototype;

--- a/packages/react-server/src/ReactFlightReplyServer.js
+++ b/packages/react-server/src/ReactFlightReplyServer.js
@@ -201,7 +201,7 @@ function reactPromiseThen<T>(
 // The shadowing `then` must be defined with `Object.defineProperty` instead of
 // assignment. Assignment would throw when `Promise.prototype` is frozen (e.g.
 // by SES lockdown) because assigning over an inherited non-writable property
-// is rejected (the "override mistake").
+// is rejected.
 Object.defineProperty(ReactPromise.prototype, 'then', {
   writable: true,
   enumerable: true,


### PR DESCRIPTION
## Summary

[Secure Ecmascript](https://github.com/tc39/proposal-ses) would freeze the prototype of intrinsics. Since `ReactPromise` inherits the prototype from `Promise`, it also copies over the writable definition. 

Using `defineProperty` on an inherited property is compatible with SES though. That's also closer to how classes are specced in JS.

## How did you test this change?

- added tests mimicking how SES would work
