### PR TITLE
[compiler] Don't flag setState calls after await in set-state-in-effect

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoSetStateInEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoSetStateInEffects.ts
@@ -24,6 +24,7 @@ import {
   Place,
   Effect,
   BlockId,
+  computeDominatorTree,
 } from '../HIR';
 import {
   eachInstructionLValue,
@@ -207,7 +208,40 @@ function getSetStateCall(
       ? createControlDominators(fn, place => isDerivedFromRef(place))
       : (): boolean => false;
 
+  /*
+   * setState calls that are only reachable after an `await` has executed run
+   * as a later continuation of the (async) effect function, not synchronously
+   * during its initial execution. Such calls don't cause the effect to
+   * synchronously trigger a cascading render the way a truly synchronous call
+   * does, so we exclude them from this validation.
+   *
+   * A block is "definitely past an await" if every path from the function
+   * entry to that block passes through a block containing an Await
+   * instruction, ie if it is dominated by such a block.
+   */
+  const blocksWithAwait: Set<BlockId> = new Set();
+  for (const [id, block] of fn.body.blocks) {
+    for (const instr of block.instructions) {
+      if (instr.value.kind === 'Await') {
+        blocksWithAwait.add(id);
+        break;
+      }
+    }
+  }
+  const dominatorTree = computeDominatorTree(fn);
+  const isDominatedByAwait = (blockId: BlockId): boolean => {
+    let current = dominatorTree.get(blockId);
+    while (current !== null) {
+      if (blocksWithAwait.has(current)) {
+        return true;
+      }
+      current = dominatorTree.get(current);
+    }
+    return false;
+  };
+
   for (const [, block] of fn.body.blocks) {
+    let pastAwait = isDominatedByAwait(block.id);
     if (enableAllowSetStateFromRefsInEffects) {
       for (const phi of block.phis) {
         if (isDerivedFromRef(phi.place)) {
@@ -288,6 +322,10 @@ function getSetStateCall(
       }
 
       switch (instr.value.kind) {
+        case 'Await': {
+          pastAwait = true;
+          break;
+        }
         case 'LoadLocal': {
           if (setStateFunctions.has(instr.value.place.identifier.id)) {
             setStateFunctions.set(
@@ -316,6 +354,9 @@ function getSetStateCall(
             isSetStateType(callee.identifier) ||
             setStateFunctions.has(callee.identifier.id)
           ) {
+            if (pastAwait) {
+              continue;
+            }
             if (enableAllowSetStateFromRefsInEffects) {
               const arg = instr.value.args.at(0);
               if (

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-setState-in-useEffect-before-await.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-setState-in-useEffect-before-await.expect.md
@@ -1,0 +1,44 @@
+
+## Input
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useEffect, useState} from 'react';
+
+function Component({id}) {
+  const [state, setState] = useState(0);
+  useEffect(async () => {
+    setState(s => s + 1);
+    await fetchData(id);
+  }, [id]);
+  return state;
+}
+
+```
+
+## Code
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import { useEffect, useState } from "react";
+
+function Component({ id }) {
+  const [state, setState] = useState(0);
+  useEffect(async () => {
+    setState((s) => s + 1);
+    await fetchData(id);
+  }, [id]);
+  return state;
+}
+
+```
+
+## Logs
+
+```
+{"kind":"CompileError","detail":{"category":"EffectSetState","reason":"Calling setState synchronously within an effect can trigger cascading renders","description":"Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:\n* Update external systems with the latest state from React.\n* Subscribe for updates from some external system, calling setState in a callback function when external state changes.\n\nCalling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect)","severity":"Error","suggestions":null,"details":[{"kind":"error","loc":{"start":{"line":7,"column":4,"index":209},"end":{"line":7,"column":12,"index":217},"filename":"invalid-setState-in-useEffect-before-await.ts","identifierName":"setState"},"message":"Avoid calling setState() directly within an effect"}]},"fnLoc":null}
+{"kind":"CompileSuccess","fnLoc":{"start":{"line":4,"column":0,"index":111},"end":{"line":11,"column":1,"index":285},"filename":"invalid-setState-in-useEffect-before-await.ts"},"fnName":"Component","memoSlots":3,"memoBlocks":1,"memoValues":2,"prunedMemoBlocks":0,"prunedMemoValues":0}
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-setState-in-useEffect-before-await.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-setState-in-useEffect-before-await.js
@@ -1,0 +1,11 @@
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useEffect, useState} from 'react';
+
+function Component({id}) {
+  const [state, setState] = useState(0);
+  useEffect(async () => {
+    setState(s => s + 1);
+    await fetchData(id);
+  }, [id]);
+  return state;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/valid-setState-in-useEffect-after-await.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/valid-setState-in-useEffect-after-await.expect.md
@@ -1,0 +1,43 @@
+
+## Input
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useEffect, useState} from 'react';
+
+function Component({id}) {
+  const [state, setState] = useState(0);
+  useEffect(async () => {
+    await fetchData(id);
+    setState(s => s + 1);
+  }, [id]);
+  return state;
+}
+
+```
+
+## Code
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import { useEffect, useState } from "react";
+
+function Component({ id }) {
+  const [state, setState] = useState(0);
+  useEffect(async () => {
+    await fetchData(id);
+    setState((s) => s + 1);
+  }, [id]);
+  return state;
+}
+
+```
+
+## Logs
+
+```
+{"kind":"CompileSuccess","fnLoc":{"start":{"line":4,"column":0,"index":111},"end":{"line":11,"column":1,"index":285},"filename":"valid-setState-in-useEffect-after-await.ts"},"fnName":"Component","memoSlots":3,"memoBlocks":1,"memoValues":2,"prunedMemoBlocks":0,"prunedMemoValues":0}
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/valid-setState-in-useEffect-after-await.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/valid-setState-in-useEffect-after-await.js
@@ -1,0 +1,11 @@
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useEffect, useState} from 'react';
+
+function Component({id}) {
+  const [state, setState] = useState(0);
+  useEffect(async () => {
+    await fetchData(id);
+    setState(s => s + 1);
+  }, [id]);
+  return state;
+}


### PR DESCRIPTION
Addresses one of the false positives reported in #34743: setState calls that occur after an await in an async effect run as a later continuation, not synchronously during the effect body, so they shouldn't trigger the set-state-in-effect cascading-render warning.

Adds two fixtures: one confirming setState before an await is still correctly flagged, and one confirming setState after an await is now valid.