### PR TITLE
[Flight] Add fuzz test for async debug info

### DIFF
--- a/packages/internal-test-utils/debugInfo.js
+++ b/packages/internal-test-utils/debugInfo.js
@@ -58,7 +58,13 @@ function normalizeIOInfo(config: DebugInfoConfig, ioInfo) {
   }
   const promise = ioInfo.value;
   if (promise) {
-    promise.then(); // init
+    // init
+    // TODO: Subscribing without a rejection handler shouldn't turn a
+    // rejected value into an unhandled rejection.
+    promise.then(
+      function () {},
+      function () {},
+    );
     if (promise.status === 'fulfilled') {
       if (ioInfo.name === 'rsc stream') {
         copy.byteSize = 0;

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoFuzz-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoFuzz-test.js
@@ -9,7 +9,8 @@
 // out with Promise.all, pass promises down as props, and await data that was
 // preloaded before the request. Some seeds abort mid-render, throw in a
 // subtree, or run two renders interleaved. A small share of the data layer
-// is userland thenables and Promise subclasses.
+// is userland thenables and Promise subclasses. The emitted debug info is
+// checked against what each seed's program actually did.
 //
 // The runs are deterministic. Every random decision is drawn while the seed
 // is being built, never while it runs. Async leaves park their resolvers
@@ -94,6 +95,42 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
 
   jest.setTimeout(60000);
 
+  // The client's performance track emits performance.measure calls. Record
+  // them (without forwarding, so an invalid span can't throw from inside
+  // React) and check basic coherence on every span.
+  let recordedMeasures;
+  const originalPerformance = {};
+  ['measure', 'mark', 'clearMeasures', 'clearMarks'].forEach(method => {
+    originalPerformance[method] = performance[method];
+  });
+  beforeEach(() => {
+    recordedMeasures = [];
+    const record = {
+      measure(measureName, options) {
+        recordedMeasures.push({name: measureName, options});
+      },
+      mark() {},
+      clearMeasures() {},
+      clearMarks() {},
+    };
+    Object.keys(originalPerformance).forEach(method => {
+      Object.defineProperty(performance, method, {
+        value: record[method],
+        configurable: true,
+        writable: true,
+      });
+    });
+  });
+  afterEach(() => {
+    Object.keys(originalPerformance).forEach(method => {
+      Object.defineProperty(performance, method, {
+        value: originalPerformance[method],
+        configurable: true,
+        writable: true,
+      });
+    });
+  });
+
   function finishLoadingStream(readable) {
     return new Promise(resolve => {
       if (readable.readableEnded) {
@@ -109,9 +146,54 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
     // that GC can never make a WeakRef-dependent field disappear from the
     // output of one run but not another.
     const retained = [];
-    // Which io kind (timer or fs read) backs each leaf id, so checks can
-    // compare the emitted attribution against what actually happened.
-    const leafKinds = new Map();
+    // The chain of named sources (innermost first, ending with the component
+    // that initiated the call) currently executing synchronously. Sources
+    // and component call sites maintain it, so each leaf records exactly
+    // which code created it.
+    let currentChain = null;
+    function named(name, fn) {
+      return {
+        [name]: function () {
+          const parentChain = currentChain;
+          currentChain =
+            parentChain === null ? [name] : [name].concat(parentChain);
+          try {
+            return fn.apply(this, arguments);
+          } finally {
+            currentChain = parentChain;
+          }
+        },
+      }[name];
+    }
+    function bumpSettleBatch() {
+      settleBatch++;
+    }
+    // Leaves whose promise is handed to a child as a prop: the child's await
+    // dedupes into the parent's, so they don't surface individually.
+    // TODO: assert exactly where they do surface instead.
+    const propLeaves = new Set();
+    function trackPropLeaves(fn) {
+      const before = nextValue;
+      const result = fn();
+      for (let i = before; i < nextValue; i++) {
+        propLeaves.add('v' + i);
+      }
+      return result;
+    }
+    function withComponent(componentName, source) {
+      const parentChain = currentChain;
+      currentChain = [componentName];
+      try {
+        return source();
+      } finally {
+        currentChain = parentChain;
+      }
+    }
+    // Ground truth per leaf id: which io kind backs it, whether it rejects,
+    // which chain of sources created it, and when the driver settled it.
+    const leafMeta = new Map();
+    let settleCount = 0;
+    let settleBatch = 0;
     // Parked leaves: {io, settle}. The driver runs io() to completion and
     // later calls settle(), possibly in the same tick as other settles.
     const pending = [];
@@ -150,7 +232,15 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
     function leaf(opts) {
       const id = 'v' + nextValue++;
       const useTimer = opts.useTimer === true;
-      leafKinds.set(id, useTimer);
+      const meta = {
+        useTimer,
+        rejects: opts.rejects === true,
+        big: opts.big === true,
+        object: opts.object === true,
+        chain: currentChain === null ? null : currentChain.slice(),
+        settleIndex: -1,
+      };
+      leafMeta.set(id, meta);
       const value = opts.big
         ? // Over the 1MB limit, so the serialized debug value gets omitted.
           id + ':' + 'x'.repeat(1100000)
@@ -161,6 +251,8 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
         pending.push({
           io: useTimer ? waitForTimer : readFromFile,
           settle() {
+            meta.settleIndex = settleCount++;
+            meta.settleBatch = settleBatch;
             if (opts.rejects) {
               reject(new Error('rejected ' + id));
             } else {
@@ -210,26 +302,26 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
         // A component fetching its own data.
         const useTimer = rand.intBetween(0, 1) === 0;
         if (rand.intBetween(0, 1) === 0) {
-          return function fetchData() {
+          return named('fetchData', function fetchData() {
             return leaf({useTimer: useTimer});
-          };
+          });
         }
-        return async function fetchAndTransform() {
+        return named('fetchAndTransform', async function fetchAndTransform() {
           const data = await leaf({useTimer: useTimer});
           return String(data).toUpperCase();
-        };
+        });
       }
       if (roll <= 40) {
         const key = rand.intBetween(0, 3);
-        return function fetchCached() {
+        return named('fetchCached', function fetchCached() {
           return cachedFetch(key);
-        };
+        });
       }
       if (roll <= 50) {
         const preloaded = pool[rand.intBetween(0, pool.length - 1)];
-        return function usePreloaded() {
+        return named('usePreloaded', function usePreloaded() {
           return preloaded;
-        };
+        });
       }
       if (roll <= 65) {
         // A waterfall: each step awaits and depends on the previous step.
@@ -238,13 +330,13 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
         for (let i = 0; i < n; i++) {
           steps.push(genSource(depth + 1));
         }
-        return async function loadWaterfall() {
+        return named('loadWaterfall', async function loadWaterfall() {
           let acc = '';
           for (let i = 0; i < steps.length; i++) {
             acc += String(await steps[i]()) + '>';
           }
           return acc;
-        };
+        });
       }
       if (roll <= 75) {
         // A fan-out.
@@ -253,44 +345,44 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
         for (let i = 0; i < n; i++) {
           parts.push(genSource(depth + 1));
         }
-        return function loadAll() {
+        return named('loadAll', function loadAll() {
           return Promise.all(parts.map(part => part()));
-        };
+        });
       }
       if (roll <= 81) {
         // A derived promise. Sometimes the callback itself blocks on more
         // data, which forks the await chain.
         const inner = genSource(depth + 1);
         const next = rand.intBetween(0, 1) === 0 ? genSource(depth + 1) : null;
-        return function loadDerived() {
+        return named('loadDerived', function loadDerived() {
           return Promise.resolve(inner()).then(function transformResult(x) {
             return next !== null ? next() : 'transformed:' + x;
           });
-        };
+        });
       }
       if (roll <= 85) {
         // Data that fails to load, handled by the data layer.
         const useTimer = rand.intBetween(0, 1) === 0;
-        return function fetchWithFallback() {
+        return named('fetchWithFallback', function fetchWithFallback() {
           return leaf({rejects: true, useTimer: useTimer}).catch(
             function useFallback(x) {
               return 'fallback:' + x.message;
             },
           );
-        };
+        });
       }
       if (roll <= 89) {
         const first = genSource(depth + 1);
         const second = genSource(depth + 1);
-        return function loadFastest() {
+        return named('loadFastest', function loadFastest() {
           return Promise.race([first(), second()]);
-        };
+        });
       }
       if (roll <= 92) {
         // Paging through an async iterator.
         const pages = [genSource(depth + 1), genSource(depth + 1)];
         const take = rand.intBetween(1, 2);
-        return async function readPages() {
+        return named('readPages', async function readPages() {
           const paginate = async function* paginate() {
             for (let i = 0; i < pages.length; i++) {
               yield await pages[i]();
@@ -309,33 +401,33 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
             await iterator.return();
           }
           return acc;
-        };
+        });
       }
       if (roll <= 94) {
-        return function loadSync() {
+        return named('loadSync', function loadSync() {
           return Promise.resolve(
             retain(Promise.resolve(retain(Promise.resolve('sync')))),
           );
-        };
+        });
       }
       if (roll <= 96) {
         // The serialized debug value of this one gets omitted for size.
         const useTimer = rand.intBetween(0, 1) === 0;
-        return function fetchLargeValue() {
+        return named('fetchLargeValue', function fetchLargeValue() {
           return leaf({big: true, useTimer: useTimer});
-        };
+        });
       }
       if (roll <= 98) {
         const useTimer = rand.intBetween(0, 1) === 0;
-        return function fetchObject() {
+        return named('fetchObject', function fetchObject() {
           return leaf({object: true, useTimer: useTimer});
-        };
+        });
       }
       if (roll <= 99) {
         // A userland thenable, like an ORM query object. Parked with the
         // driver like other leaves; resolves to more data.
         const inner = genSource(depth + 1);
-        return function queryThenable() {
+        return named('queryThenable', function queryThenable() {
           return {
             then(resolve) {
               pending.push({
@@ -346,10 +438,10 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
               });
             },
           };
-        };
+        });
       }
       // A Promise subclass, like a polyfill or instrumented promise.
-      return function subclassedFetch() {
+      return named('subclassedFetch', function subclassedFetch() {
         return new FuzzPromise(resolve => {
           pending.push({
             io: async function noIO() {},
@@ -358,10 +450,23 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
             },
           });
         });
-      };
+      });
     }
 
-    return {retained, pending, pool, genSource, leaf, retain, leafKinds};
+    return {
+      retained,
+      pending,
+      pool,
+      genSource,
+      leaf,
+      retain,
+      leafMeta,
+      named,
+      withComponent,
+      bumpSettleBatch,
+      propLeaves,
+      trackPropLeaves,
+    };
   }
 
   function buildComponents(rand, program, componentRoots, componentCreators) {
@@ -372,11 +477,14 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
     function makeSyncUseComponent(options) {
       const name = 'FuzzUse' + componentId++;
       componentRoots.set(name, options.rootIndex);
+      options.useComponents.add(name);
       const source = once(program.genSource(2));
       const Component = {
         [name]: function () {
           const value = ReactServer.use(
-            program.retain(Promise.resolve(source())),
+            program.retain(
+              Promise.resolve(program.withComponent(name, source)),
+            ),
           );
           return name + ':' + String(value);
         },
@@ -394,12 +502,18 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
       }
       // Awaits happen one after the other or all at once.
       const parallel = rand.intBetween(0, 2) === 0;
+      if (parallel) {
+        options.parallelComponents.add(name);
+      }
       // Sometimes the component's own data fails and it renders a fallback.
       const catches = rand.intBetween(0, 5) === 0;
       const catchesIOKind = catches ? rand.intBetween(0, 1) === 0 : false;
       // Sometimes the component has a bug and throws. The subtree errors
       // but the rest of the render completes.
       const throws = options.canThrow && rand.intBetween(0, 19) === 0;
+      if (throws) {
+        options.throwers.add(name);
+      }
 
       const children = [];
       if (depth < 3) {
@@ -443,23 +557,33 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
       // throws while the component's debug info is serialized, the server
       // degrades the debug info to a string, and the client then corrupts
       // the component's data chunk while failing to initialize it.
-      const propSource = children.length > 0 && rand.intBetween(0, 2) === 0;
+      const propSource =
+        children.length > 0 &&
+        // use() components ignore their props, so a promise prop passed to
+        // one would never be awaited by anyone.
+        !options.useComponents.has(children[0].name) &&
+        rand.intBetween(0, 2) === 0;
 
       const Component = {
         [name]: async function (props) {
           let out = name + ':';
           if (parallel) {
-            const values = await Promise.all(sources.map(source => source()));
+            const values = await Promise.all(
+              sources.map(source => program.withComponent(name, source)),
+            );
             out += values.map(String).join(';');
           } else {
             for (let i = 0; i < sources.length; i++) {
-              out += String(await sources[i]()) + ';';
+              out +=
+                String(await program.withComponent(name, sources[i])) + ';';
             }
           }
           if (catches) {
             try {
               out += String(
-                await program.leaf({rejects: true, useTimer: catchesIOKind}),
+                await program.withComponent(name, () =>
+                  program.leaf({rejects: true, useTimer: catchesIOKind}),
+                ),
               );
             } catch (x) {
               out += 'recovered';
@@ -481,7 +605,13 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
               key: i,
               data:
                 i === 0 && propSource
-                  ? program.retain(Promise.resolve(sources[0]()))
+                  ? program.retain(
+                      Promise.resolve(
+                        program.trackPropLeaves(() =>
+                          program.withComponent(name, sources[0]),
+                        ),
+                      ),
+                    )
                   : null,
               slot: i === 0 ? slotElement : null,
             }),
@@ -542,6 +672,7 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
           batch[i].settle();
           onSettle();
         }
+        program.bumpSettleBatch();
       }
       const hops = rand.intBetween(1, 3);
       for (let i = 0; i < hops; i++) {
@@ -560,8 +691,207 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
     }
   }
 
+  // ---- Computed oracle ----
+  // Every check below derives from what the seed's program actually did, as
+  // recorded by the generator (creator and invocation chains, leaf io kinds,
+  // values) and the driver (settle order), so it holds for any seed.
+
+  function leafIdOfValue(settled) {
+    if (settled == null || settled.status !== 'fulfilled') {
+      return null;
+    }
+    const value = settled.value;
+    if (typeof value === 'string' && /^v[0-9]+$/.test(value)) {
+      return value;
+    }
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      typeof value.id === 'string' &&
+      /^v[0-9]+$/.test(value.id)
+    ) {
+      return value.id;
+    }
+    return null;
+  }
+
+  function creatorChain(name, componentCreators) {
+    const chain = [];
+    let current = name;
+    while (componentCreators.get(current) != null) {
+      current = componentCreators.get(current);
+      chain.push(current);
+    }
+    return chain;
+  }
+
+  function validateDebugInfo(debugInfo, ctx) {
+    const {
+      componentRoots,
+      componentCreators,
+      leafMeta,
+      rootIndex,
+      violations,
+      leafSightings,
+      orderSamples,
+    } = ctx;
+    let lastTime = -Infinity;
+    debugInfo.forEach(entry => {
+      if (typeof entry.time === 'number') {
+        if (entry.time < lastTime) {
+          violations.push(
+            'time went backwards: ' + entry.time + ' after ' + lastTime,
+          );
+        }
+        lastTime = entry.time;
+      }
+      // The generator knows which component's body created each element, so
+      // the emitted owner chain can be checked against what actually
+      // happened, all the way up.
+      if (
+        typeof entry.name === 'string' &&
+        entry.awaited === undefined &&
+        componentCreators.has(entry.name)
+      ) {
+        const expected = componentCreators.get(entry.name);
+        const actual = entry.owner != null ? entry.owner.name : null;
+        if (actual !== expected) {
+          violations.push(
+            'component ' +
+              entry.name +
+              ' has owner ' +
+              actual +
+              ' but its element was created by ' +
+              expected,
+          );
+        } else if (entry.owner != null) {
+          const expectedChain = creatorChain(entry.name, componentCreators);
+          const actualChain = [];
+          let chainOwner = entry.owner;
+          while (chainOwner != null) {
+            actualChain.push(chainOwner.name);
+            chainOwner = chainOwner.owner;
+          }
+          if (actualChain.join('<') !== expectedChain.join('<')) {
+            violations.push(
+              'component ' +
+                entry.name +
+                ' has owner chain ' +
+                actualChain.join('<') +
+                ' but was created under ' +
+                expectedChain.join('<'),
+            );
+          }
+        }
+      }
+      let owner = entry.owner;
+      const seen = new Set();
+      while (owner != null) {
+        if (seen.has(owner)) {
+          violations.push('owner cycle at ' + owner.name);
+          break;
+        }
+        seen.add(owner);
+        if (
+          componentRoots.has(owner.name) &&
+          componentRoots.get(owner.name) !== rootIndex
+        ) {
+          violations.push('owner ' + owner.name + ' belongs to another render');
+        }
+        owner = owner.owner;
+      }
+      const io = entry.awaited;
+      if (io) {
+        if (
+          typeof io.start === 'number' &&
+          typeof io.end === 'number' &&
+          io.end >= 0 &&
+          io.end < io.start
+        ) {
+          violations.push(
+            'io ended before it started: ' +
+              io.name +
+              ' ' +
+              io.start +
+              '..' +
+              io.end,
+          );
+        }
+        if (io.stack && io.stack.length > 0 && io.name === '') {
+          violations.push('io with a stack but no name');
+        }
+        if (typeof io.byteSize === 'number' && io.byteSize < 0) {
+          violations.push('negative byteSize');
+        }
+        const leafId = leafIdOfValue(io.value);
+        if (leafId !== null) {
+          const meta = leafMeta.get(leafId);
+          if (meta === undefined) {
+            violations.push('io resolved to unknown leaf ' + leafId);
+          } else {
+            leafSightings.set(leafId, (leafSightings.get(leafId) || 0) + 1);
+            const frames = io.stack ? io.stack.map(frame => frame[0]) : [];
+            if (meta.useTimer && frames.indexOf('readFixture') !== -1) {
+              violations.push(
+                leafId + ' used a timer but its io stack reads a file',
+              );
+            }
+            if (!meta.useTimer && frames.indexOf('sleep') !== -1) {
+              violations.push(
+                leafId + ' read a file but its io stack is a timer',
+              );
+            }
+            // A leaf initiated by one render's component must never be
+            // attributed inside the other render.
+            if (meta.chain !== null) {
+              const initiator = meta.chain[meta.chain.length - 1];
+              if (
+                componentRoots.has(initiator) &&
+                componentRoots.get(initiator) !== rootIndex
+              ) {
+                violations.push(
+                  leafId +
+                    ' was initiated by the other render (' +
+                    initiator +
+                    ')',
+                );
+              }
+            }
+            // The recorded value must be exactly what the leaf resolved to.
+            const value = io.value.value;
+            if (meta.object) {
+              if (value.id !== leafId || String(value.items) !== '1,2,3') {
+                violations.push(leafId + ' object value corrupted');
+              }
+            } else if (!meta.big && value !== leafId) {
+              violations.push(
+                leafId + ' value corrupted: ' + JSON.stringify(value),
+              );
+            }
+            if (typeof io.end === 'number' && io.end >= 0) {
+              orderSamples.push({
+                leafId,
+                settleBatch: meta.settleBatch,
+                end: io.end,
+              });
+            }
+          }
+        } else if (
+          io.value != null &&
+          io.value.status === 'fulfilled' &&
+          typeof io.value.value === 'string' &&
+          io.value.value.indexOf('x'.repeat(1000)) !== -1
+        ) {
+          // Big leaf values must be replaced by the omission placeholder;
+          // the raw megabyte string must never reach the client.
+          violations.push('a large debug value was not omitted');
+        }
+      }
+    });
+  }
+
   // Collect debug info from the resolved client tree, in traversal order.
-  function collectDebugInfo(root) {
+  function collectDebugInfo(root, ctx) {
     const out = [];
     const visited = new Set();
     const queue = [root];
@@ -576,6 +906,7 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
       }
       visited.add(value);
       if (value._debugInfo) {
+        validateDebugInfo(value._debugInfo, ctx);
         out.push(value._debugInfo);
       }
       if (Array.isArray(value)) {
@@ -672,11 +1003,17 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
     // the first render partway through.
     const concurrentRenders = rand.intBetween(0, 3) === 0 ? 2 : 1;
     const abortAfter = rand.intBetween(0, 5) === 0 ? rand.intBetween(2, 8) : -1;
+    const throwers = new Set();
+    const parallelComponents = new Set();
+    const useComponents = new Set();
     const roots = [];
     for (let i = 0; i < concurrentRenders; i++) {
       const Root = makeComponent(0, {
         canThrow: abortAfter === -1,
         rootIndex: i,
+        throwers,
+        parallelComponents,
+        useComponents,
       });
       // Root elements are created outside any component.
       componentCreators.set(Root.name, null);
@@ -742,8 +1079,21 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
     });
     await allDone;
 
+    const violations = [];
     const output = [];
+    const contexts = [];
     for (let i = 0; i < results.length; i++) {
+      const ctx = {
+        componentRoots,
+        componentCreators,
+        leafMeta: program.leafMeta,
+        rootIndex: i,
+        violations,
+        leafSightings: new Map(),
+        orderSamples: [],
+        collected: false,
+      };
+      contexts.push(ctx);
       let value;
       try {
         value = await results[i];
@@ -751,17 +1101,153 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
         output.push({value: 'root rejected: ' + x.message, debugInfo: []});
         continue;
       }
+      ctx.collected = true;
       output.push({
         value: summarize(value),
-        debugInfo: collectDebugInfo(value),
+        // Walk from the root chunk itself: when the root model resolves to a
+        // primitive, its debug info has no value to move onto and stays on
+        // the chunk.
+        debugInfo: collectDebugInfo(results[i], ctx),
       });
     }
+
+    // Components under a throwing component never finish rendering, so
+    // their data is exempt from the completeness check.
+    const exempt = new Set();
+    componentCreators.forEach((creator, componentName) => {
+      let current = componentName;
+      while (current != null) {
+        if (throwers.has(current)) {
+          exempt.add(componentName);
+          break;
+        }
+        current = componentCreators.get(current);
+      }
+    });
+
+    contexts.forEach(ctx => {
+      // Dedup: shared data legitimately appears once per awaiting component
+      // (plus forks), so the bound is the number of components in the
+      // render. Exponential accumulation blows past it immediately.
+      let componentCount = 0;
+      componentRoots.forEach(root => {
+        if (root === ctx.rootIndex) {
+          componentCount++;
+        }
+      });
+      ctx.leafSightings.forEach((count, leafId) => {
+        if (count > componentCount + 4) {
+          violations.push(
+            leafId + ' appears ' + count + ' times in one request',
+          );
+        }
+      });
+      // Settle order: the driver settled leaves one batch at a time, so io
+      // end times must be ordered like the settles were.
+      // Within one batch the recurring pings of different ios interleave, so
+      // ordering is only guaranteed across batches.
+      const samples = [];
+      const sampled = new Set();
+      ctx.orderSamples.forEach(sample => {
+        if (sample.settleBatch !== undefined && !sampled.has(sample.leafId)) {
+          sampled.add(sample.leafId);
+          samples.push(sample);
+        }
+      });
+      samples.sort((a, b) => a.settleBatch - b.settleBatch);
+      for (let i = 1; i < samples.length; i++) {
+        if (
+          samples[i].settleBatch > samples[i - 1].settleBatch &&
+          samples[i].end < samples[i - 1].end - 0.001
+        ) {
+          violations.push(
+            'io end times out of settle order: ' +
+              samples[i - 1].leafId +
+              ' then ' +
+              samples[i].leafId,
+          );
+        }
+      }
+    });
+
+    // Completeness: every leaf a component actually fetched and settled must
+    // be attributed somewhere in that component's render. Exemptions, each
+    // for a reason: aborted renders (the abort races the io), rejected roots
+    // (nothing was collected), throwing subtrees (they never finish),
+    // combinator and parallel awaits (only the io that unblocked them is
+    // attributed -- TODO: the driver knows the settle order, so the
+    // unblocker is predictable; assert it exactly), use() components (the
+    // used promise carries the transformed value, so there is nothing to
+    // join on), and pre-request pool data (no initiating component).
+    if (abortAfter === -1) {
+      program.leafMeta.forEach((meta, leafId) => {
+        if (
+          meta.chain === null ||
+          meta.rejects ||
+          meta.big ||
+          meta.settleIndex === -1 ||
+          meta.chain.indexOf('loadFastest') !== -1 ||
+          meta.chain.indexOf('loadAll') !== -1 ||
+          meta.chain.indexOf('readPages') !== -1 ||
+          meta.chain.indexOf('queryThenable') !== -1 ||
+          program.propLeaves.has(leafId)
+        ) {
+          return;
+        }
+        const initiator = meta.chain[meta.chain.length - 1];
+        if (
+          !componentRoots.has(initiator) ||
+          exempt.has(initiator) ||
+          parallelComponents.has(initiator) ||
+          useComponents.has(initiator)
+        ) {
+          return;
+        }
+        const ctx = contexts[componentRoots.get(initiator)];
+        if (ctx && ctx.collected === true && !ctx.leafSightings.has(leafId)) {
+          violations.push(
+            leafId +
+              ' (' +
+              meta.chain.join('<') +
+              ') settled but never appeared in the debug info',
+          );
+        }
+      });
+    }
+
     // The client flushes the performance track on a 100ms timer after the
-    // last pending chunk resolves. Wait it out so the flush happens during
-    // this test instead of during whatever runs next.
+    // last pending chunk resolves. Wait it out so the flush lands in this
+    // seed's recording instead of on the global timeline during a later test.
     await new Promise(resolve => setTimeout(resolve, 150));
 
-    return output;
+    // Performance track spans.
+    recordedMeasures.forEach(measure => {
+      const options = measure.options;
+      if (
+        options == null ||
+        !Number.isFinite(options.start) ||
+        !Number.isFinite(options.end)
+      ) {
+        violations.push('measure without finite start/end: ' + measure.name);
+      } else if (options.end < options.start) {
+        violations.push(
+          'span with negative width: ' +
+            measure.name +
+            ' ' +
+            options.start +
+            '..' +
+            options.end,
+        );
+      } else if (
+        options.detail == null ||
+        options.detail.devtools == null ||
+        typeof options.detail.devtools.track !== 'string'
+      ) {
+        violations.push('measure without a track: ' + measure.name);
+      }
+    });
+
+    return {output, violations, measureCount: recordedMeasures.length};
   }
 
   // FUZZ_TEST_SEED reruns or explores any seed: every check is computed from
@@ -776,9 +1262,22 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
     }
   }
   seeds.forEach(seed => {
-    it(`produces stable async debug info (seed ${seed})`, async () => {
+    it(`produces coherent async debug info (seed ${seed})`, async () => {
       // Render unconditionally so we catch any production crashes
-      await runSeed(seed);
+      const {output, violations, measureCount} = await runSeed(seed);
+      if (
+        __DEV__ &&
+        gate(
+          flags =>
+            flags.enableComponentPerformanceTrack && flags.enableAsyncDebugInfo,
+        )
+      ) {
+        expect(violations).toEqual([]);
+        if (output[0].debugInfo.length > 0) {
+          // The client flushed the performance track for the initial render.
+          expect(measureCount).toBeGreaterThan(0);
+        }
+      }
     });
   });
 });

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoFuzz-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoFuzz-test.js
@@ -1,0 +1,784 @@
+/**
+ * @jest-environment node
+ */
+'use strict';
+
+// Generative test for the async debug info tracking. Each seed builds a
+// random Flight render shaped like a real app: components fetch their own
+// data, share a cache()-deduped data layer, waterfall through helpers, fan
+// out with Promise.all, pass promises down as props, and await data that was
+// preloaded before the request. Some seeds abort mid-render, throw in a
+// subtree, or run two renders interleaved. A small share of the data layer
+// is userland thenables and Promise subclasses.
+//
+// The runs are deterministic. Every random decision is drawn while the seed
+// is being built, never while it runs. Async leaves park their resolvers
+// with a driver; a seeded loop runs each leaf's real I/O to completion (one
+// at a time, so its latency can't reorder anything), then settles batches of
+// leaves back to back in the same tick, with seeded microtask and macrotask
+// hops in between. Times are normalized and stacks are compared by function
+// name only, so the snapshots are stable across machines and runs.
+//
+// To debug or explore a single seed: FUZZ_TEST_SEED=<n> yarn test ReactFlightAsyncDebugInfoFuzz
+
+import {patchSetImmediate} from '../../../../scripts/jest/patchSetImmediate';
+
+import fs from 'fs';
+import path from 'path';
+
+let ReactServer;
+let ReactServerDOMServer;
+let ReactServerDOMClient;
+let Stream;
+let Random;
+
+const NUM_SEEDS = 20;
+const ONLY_SEED =
+  process.env.FUZZ_TEST_SEED != null ? +process.env.FUZZ_TEST_SEED : null;
+
+const streamOptions = {
+  objectMode: true,
+};
+
+function filterStackFrame(filename, functionName) {
+  return (
+    !filename.startsWith('node:') &&
+    !filename.includes('node_modules') &&
+    // Filter out our own internal source code since it'll typically be in node_modules
+    (!filename.includes('/packages/') || filename.includes('/__tests__/')) &&
+    !filename.includes('/build/') &&
+    !functionName.includes('internal_')
+  );
+}
+
+class FuzzPromise extends Promise {}
+
+function once(source) {
+  let memo = null;
+  return function memoizedSource() {
+    if (memo === null) {
+      memo = source();
+    }
+    return memo;
+  };
+}
+
+describe('ReactFlightAsyncDebugInfoFuzz', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useRealTimers();
+    patchSetImmediate();
+    global.console = require('console');
+
+    jest.mock('react', () => require('react/react.react-server'));
+    jest.mock('react-server-dom-webpack/server', () =>
+      jest.requireActual('react-server-dom-webpack/server.node'),
+    );
+    ReactServer = require('react');
+    ReactServerDOMServer = require('react-server-dom-webpack/server');
+
+    jest.resetModules();
+    jest.useRealTimers();
+    patchSetImmediate();
+
+    __unmockReact();
+    jest.unmock('react-server-dom-webpack/server');
+    jest.mock('react-server-dom-webpack/client', () =>
+      jest.requireActual('react-server-dom-webpack/client.node'),
+    );
+
+    ReactServerDOMClient = require('react-server-dom-webpack/client');
+    Stream = require('stream');
+    Random = require('random-seed');
+  });
+
+  jest.setTimeout(60000);
+
+  function finishLoadingStream(readable) {
+    return new Promise(resolve => {
+      if (readable.readableEnded) {
+        resolve();
+      } else {
+        readable.on('end', () => resolve());
+      }
+    });
+  }
+
+  function createProgram(rand) {
+    // Everything the program allocates is retained until the test ends so
+    // that GC can never make a WeakRef-dependent field disappear from the
+    // output of one run but not another.
+    const retained = [];
+    // Which io kind (timer or fs read) backs each leaf id, so checks can
+    // compare the emitted attribution against what actually happened.
+    const leafKinds = new Map();
+    // Parked leaves: {io, settle}. The driver runs io() to completion and
+    // later calls settle(), possibly in the same tick as other settles.
+    const pending = [];
+    let nextValue = 0;
+
+    function retain(x) {
+      retained.push(x);
+      return x;
+    }
+
+    // The two kinds of real I/O behind every leaf. Their names are what the
+    // io debug entries get attributed to.
+    function readFromFile() {
+      return new Promise(function readFixture(resolve, reject) {
+        fs.readFile(
+          path.join(__dirname, '../ReactFlightAsyncSequence.js'),
+          function onFileRead(error) {
+            if (error) {
+              reject(error);
+            } else {
+              resolve();
+            }
+          },
+        );
+      });
+    }
+    function waitForTimer() {
+      return new Promise(function sleep(resolve) {
+        setTimeout(resolve, 1);
+      });
+    }
+
+    // A promise backed by one unit of real I/O whose resolution is parked
+    // with the driver. The io kind is decided when the seed is built, never
+    // when the leaf is created.
+    function leaf(opts) {
+      const id = 'v' + nextValue++;
+      const useTimer = opts.useTimer === true;
+      leafKinds.set(id, useTimer);
+      const value = opts.big
+        ? // Over the 1MB limit, so the serialized debug value gets omitted.
+          id + ':' + 'x'.repeat(1100000)
+        : opts.object
+          ? {id: id, items: [1, 2, 3]}
+          : id;
+      const promise = new Promise((resolve, reject) => {
+        pending.push({
+          io: useTimer ? waitForTimer : readFromFile,
+          settle() {
+            if (opts.rejects) {
+              reject(new Error('rejected ' + id));
+            } else {
+              resolve(value);
+            }
+          },
+        });
+      });
+      if (opts.rejects) {
+        // The driver may settle this before a consumer has attached its
+        // handler; mark it handled so that can't fail the test run. This
+        // adds one extra tracked await around every rejecting leaf, which
+        // is visible in the snapshots.
+        retain(promise.catch(function ignoreUnhandled() {}));
+      }
+      return retain(promise);
+    }
+
+    // ---- Sources ----
+    // A source is a thunk. Components (and their helpers) invoke sources
+    // while they run, so most promises are created during the render with
+    // an owner, like data fetching in a real app. All random decisions are
+    // made here at build time; running a thunk never draws from the seed.
+
+    // Module-scope data: created before the render starts. A seeded subset
+    // resolves before the request begins, so some awaits point at I/O that
+    // finished before the request's time origin.
+    const pool = [];
+    for (let i = 0; i < 4; i++) {
+      pool.push(leaf({useTimer: rand.intBetween(0, 1) === 0}));
+    }
+
+    // Request-deduped data layer. The fetch happens inside the cache scope,
+    // so components using the same key share one fetch per request.
+    const cachedIOKinds = [];
+    for (let i = 0; i < 4; i++) {
+      cachedIOKinds.push(rand.intBetween(0, 1) === 0);
+    }
+    const cachedFetch = ReactServer.cache(async function cachedFetch(key) {
+      const data = await leaf({useTimer: cachedIOKinds[key]});
+      return 'cached:' + key + ':' + data;
+    });
+
+    function genSource(depth) {
+      const roll = rand.intBetween(1, 100);
+      if (roll <= 25 || depth >= 3) {
+        // A component fetching its own data.
+        const useTimer = rand.intBetween(0, 1) === 0;
+        if (rand.intBetween(0, 1) === 0) {
+          return function fetchData() {
+            return leaf({useTimer: useTimer});
+          };
+        }
+        return async function fetchAndTransform() {
+          const data = await leaf({useTimer: useTimer});
+          return String(data).toUpperCase();
+        };
+      }
+      if (roll <= 40) {
+        const key = rand.intBetween(0, 3);
+        return function fetchCached() {
+          return cachedFetch(key);
+        };
+      }
+      if (roll <= 50) {
+        const preloaded = pool[rand.intBetween(0, pool.length - 1)];
+        return function usePreloaded() {
+          return preloaded;
+        };
+      }
+      if (roll <= 65) {
+        // A waterfall: each step awaits and depends on the previous step.
+        const steps = [];
+        const n = rand.intBetween(2, 4);
+        for (let i = 0; i < n; i++) {
+          steps.push(genSource(depth + 1));
+        }
+        return async function loadWaterfall() {
+          let acc = '';
+          for (let i = 0; i < steps.length; i++) {
+            acc += String(await steps[i]()) + '>';
+          }
+          return acc;
+        };
+      }
+      if (roll <= 75) {
+        // A fan-out.
+        const parts = [];
+        const n = rand.intBetween(2, 3);
+        for (let i = 0; i < n; i++) {
+          parts.push(genSource(depth + 1));
+        }
+        return function loadAll() {
+          return Promise.all(parts.map(part => part()));
+        };
+      }
+      if (roll <= 81) {
+        // A derived promise. Sometimes the callback itself blocks on more
+        // data, which forks the await chain.
+        const inner = genSource(depth + 1);
+        const next = rand.intBetween(0, 1) === 0 ? genSource(depth + 1) : null;
+        return function loadDerived() {
+          return Promise.resolve(inner()).then(function transformResult(x) {
+            return next !== null ? next() : 'transformed:' + x;
+          });
+        };
+      }
+      if (roll <= 85) {
+        // Data that fails to load, handled by the data layer.
+        const useTimer = rand.intBetween(0, 1) === 0;
+        return function fetchWithFallback() {
+          return leaf({rejects: true, useTimer: useTimer}).catch(
+            function useFallback(x) {
+              return 'fallback:' + x.message;
+            },
+          );
+        };
+      }
+      if (roll <= 89) {
+        const first = genSource(depth + 1);
+        const second = genSource(depth + 1);
+        return function loadFastest() {
+          return Promise.race([first(), second()]);
+        };
+      }
+      if (roll <= 92) {
+        // Paging through an async iterator.
+        const pages = [genSource(depth + 1), genSource(depth + 1)];
+        const take = rand.intBetween(1, 2);
+        return async function readPages() {
+          const paginate = async function* paginate() {
+            for (let i = 0; i < pages.length; i++) {
+              yield await pages[i]();
+            }
+          };
+          const iterator = paginate();
+          let acc = '';
+          for (let i = 0; i < take; i++) {
+            const step = await iterator.next();
+            if (step.done) {
+              break;
+            }
+            acc += String(step.value) + '|';
+          }
+          if (iterator.return) {
+            await iterator.return();
+          }
+          return acc;
+        };
+      }
+      if (roll <= 94) {
+        return function loadSync() {
+          return Promise.resolve(
+            retain(Promise.resolve(retain(Promise.resolve('sync')))),
+          );
+        };
+      }
+      if (roll <= 96) {
+        // The serialized debug value of this one gets omitted for size.
+        const useTimer = rand.intBetween(0, 1) === 0;
+        return function fetchLargeValue() {
+          return leaf({big: true, useTimer: useTimer});
+        };
+      }
+      if (roll <= 98) {
+        const useTimer = rand.intBetween(0, 1) === 0;
+        return function fetchObject() {
+          return leaf({object: true, useTimer: useTimer});
+        };
+      }
+      if (roll <= 99) {
+        // A userland thenable, like an ORM query object. Parked with the
+        // driver like other leaves; resolves to more data.
+        const inner = genSource(depth + 1);
+        return function queryThenable() {
+          return {
+            then(resolve) {
+              pending.push({
+                io: async function noIO() {},
+                settle() {
+                  resolve(retain(Promise.resolve(inner())));
+                },
+              });
+            },
+          };
+        };
+      }
+      // A Promise subclass, like a polyfill or instrumented promise.
+      return function subclassedFetch() {
+        return new FuzzPromise(resolve => {
+          pending.push({
+            io: async function noIO() {},
+            settle() {
+              resolve('sub' + nextValue++);
+            },
+          });
+        });
+      };
+    }
+
+    return {retained, pending, pool, genSource, leaf, retain, leafKinds};
+  }
+
+  function buildComponents(rand, program, componentRoots, componentCreators) {
+    let componentId = 0;
+
+    // use() must observe the same thenable when the component replays, so
+    // the source is memoized.
+    function makeSyncUseComponent(options) {
+      const name = 'FuzzUse' + componentId++;
+      componentRoots.set(name, options.rootIndex);
+      const source = once(program.genSource(2));
+      const Component = {
+        [name]: function () {
+          const value = ReactServer.use(
+            program.retain(Promise.resolve(source())),
+          );
+          return name + ':' + String(value);
+        },
+      }[name];
+      return Component;
+    }
+
+    function makeComponent(depth, options) {
+      const name = 'Fuzz' + componentId++;
+      componentRoots.set(name, options.rootIndex);
+      const sources = [];
+      const nAwaits = rand.intBetween(1, 2);
+      for (let i = 0; i < nAwaits; i++) {
+        sources.push(program.genSource(0));
+      }
+      // Awaits happen one after the other or all at once.
+      const parallel = rand.intBetween(0, 2) === 0;
+      // Sometimes the component's own data fails and it renders a fallback.
+      const catches = rand.intBetween(0, 5) === 0;
+      const catchesIOKind = catches ? rand.intBetween(0, 1) === 0 : false;
+      // Sometimes the component has a bug and throws. The subtree errors
+      // but the rest of the render completes.
+      const throws = options.canThrow && rand.intBetween(0, 19) === 0;
+
+      const children = [];
+      if (depth < 3) {
+        const nChildren = rand.intBetween(0, depth === 0 ? 3 : 2);
+        for (let i = 0; i < nChildren; i++) {
+          children.push(
+            rand.intBetween(0, 4) === 0
+              ? makeSyncUseComponent(options)
+              : makeComponent(depth + 1, options),
+          );
+        }
+      }
+      // A slot: the parent creates an element during its own render and the
+      // first child renders it, so the element's owner is not its parent in
+      // the tree. Sometimes the parent also renders the same element itself,
+      // which dedupes it across two locations.
+      const SlotComponent =
+        children.length > 0 && rand.intBetween(0, 2) === 0
+          ? makeComponent(depth + 1, options)
+          : null;
+      // This component's body creates the child and slot elements, so it is
+      // their owner regardless of where they render.
+      children.forEach(Child => componentCreators.set(Child.name, name));
+      if (SlotComponent !== null) {
+        componentCreators.set(SlotComponent.name, name);
+      }
+      const dedupesSlot = SlotComponent !== null && rand.intBetween(0, 1) === 0;
+      // Most components return [text, children]; some return a single child
+      // element or just text.
+      const returnShape =
+        children.length > 0 && rand.intBetween(0, 3) === 0
+          ? 'element'
+          : rand.intBetween(0, 5) === 0
+            ? 'text'
+            : 'array';
+
+      // A promise started by the parent and awaited by the first child.
+      // TODO: Pass the source's raw result once debug info serialization
+      // survives props that throw on unexpected property access (like our
+      // own ClientReference proxies do). JSON.stringify's toJSON probe
+      // throws while the component's debug info is serialized, the server
+      // degrades the debug info to a string, and the client then corrupts
+      // the component's data chunk while failing to initialize it.
+      const propSource = children.length > 0 && rand.intBetween(0, 2) === 0;
+
+      const Component = {
+        [name]: async function (props) {
+          let out = name + ':';
+          if (parallel) {
+            const values = await Promise.all(sources.map(source => source()));
+            out += values.map(String).join(';');
+          } else {
+            for (let i = 0; i < sources.length; i++) {
+              out += String(await sources[i]()) + ';';
+            }
+          }
+          if (catches) {
+            try {
+              out += String(
+                await program.leaf({rejects: true, useTimer: catchesIOKind}),
+              );
+            } catch (x) {
+              out += 'recovered';
+            }
+          }
+          if (throws) {
+            throw new Error('bug in ' + name);
+          }
+          if (props != null && props.data != null) {
+            out += '/data:' + String(await props.data);
+          }
+          const slot = props != null && props.slot != null ? props.slot : null;
+          const slotElement =
+            SlotComponent !== null
+              ? ReactServer.createElement(SlotComponent, {key: 'slot'})
+              : null;
+          const childElements = children.map((Child, i) =>
+            ReactServer.createElement(Child, {
+              key: i,
+              data:
+                i === 0 && propSource
+                  ? program.retain(Promise.resolve(sources[0]()))
+                  : null,
+              slot: i === 0 ? slotElement : null,
+            }),
+          );
+          if (slot !== null) {
+            childElements.push(slot);
+          }
+          if (dedupesSlot) {
+            childElements.push(slotElement);
+          }
+          if (returnShape === 'element' && childElements.length > 0) {
+            return childElements[0];
+          }
+          if (returnShape === 'text' && childElements.length === 0) {
+            return out;
+          }
+          return [out, childElements];
+        },
+      }[name];
+      return Component;
+    }
+
+    return {makeComponent};
+  }
+
+  async function drive(rand, program, doneRef, onSettle) {
+    // Fire parked leaves in seeded-random order. Real I/O runs one at a
+    // time so its latency can never reorder events, but settles are batched
+    // back to back in one tick so continuations of different leaves
+    // interleave within the same microtask flush.
+    let iterations = 0;
+    while (!doneRef.done || program.pending.length > 0) {
+      if (iterations++ > 10000) {
+        throw new Error('driver did not converge');
+      }
+      if (program.pending.length > 0) {
+        const batchSize = Math.min(
+          program.pending.length,
+          rand.intBetween(1, 3),
+        );
+        const batch = [];
+        for (let i = 0; i < batchSize; i++) {
+          const idx = rand.intBetween(0, program.pending.length - 1);
+          batch.push(program.pending.splice(idx, 1)[0]);
+        }
+        // Drain everything the render scheduled (including chains of it)
+        // before touching real I/O, so that nothing is pending while the
+        // I/O runs and its real-world latency can't reorder anything.
+        for (let i = 0; i < 6; i++) {
+          await new Promise(resolve => {
+            setTimeout(resolve, 0);
+          });
+        }
+        for (let i = 0; i < batch.length; i++) {
+          await batch[i].io();
+        }
+        for (let i = 0; i < batch.length; i++) {
+          batch[i].settle();
+          onSettle();
+        }
+      }
+      const hops = rand.intBetween(1, 3);
+      for (let i = 0; i < hops; i++) {
+        switch (rand.intBetween(0, 2)) {
+          case 0:
+            await null;
+            break;
+          case 1:
+            await new Promise(resolve => setImmediate(resolve));
+            break;
+          default:
+            await new Promise(resolve => process.nextTick(resolve));
+            break;
+        }
+      }
+    }
+  }
+
+  // Collect debug info from the resolved client tree, in traversal order.
+  function collectDebugInfo(root) {
+    const out = [];
+    const visited = new Set();
+    const queue = [root];
+    let budget = 2000;
+    while (queue.length > 0) {
+      if (budget-- === 0) {
+        throw new Error('debug info walker exceeded its budget');
+      }
+      const value = queue.shift();
+      if (value === null || typeof value !== 'object' || visited.has(value)) {
+        continue;
+      }
+      visited.add(value);
+      if (value._debugInfo) {
+        out.push(value._debugInfo);
+      }
+      if (Array.isArray(value)) {
+        value.forEach(entry => queue.push(entry));
+      } else if (value.$$typeof === Symbol.for('react.transitional.element')) {
+        queue.push(value.props.children);
+        if (value.props.data != null) {
+          queue.push(value.props.data);
+        }
+        if (value.props.slot != null) {
+          queue.push(value.props.slot);
+        }
+      } else if (value.$$typeof === Symbol.for('react.lazy')) {
+        // An aborted or errored subtree stays a lazy wrapper around its
+        // chunk.
+        queue.push(value._payload);
+      } else if (typeof value.then === 'function') {
+        if (value.status === 'fulfilled') {
+          queue.push(value.value);
+        }
+      }
+    }
+    return out;
+  }
+
+  function summarize(value) {
+    if (value === null || value === undefined) {
+      return String(value);
+    }
+    if (typeof value === 'string') {
+      return value.length > 40 ? value.slice(0, 40) + '…' : value;
+    }
+    if (typeof value === 'number') {
+      return String(value);
+    }
+    if (Array.isArray(value)) {
+      return '[' + value.map(summarize).join(',') + ']';
+    }
+    if (value.$$typeof === Symbol.for('react.transitional.element')) {
+      const name =
+        typeof value.type === 'string'
+          ? value.type
+          : value.type.name || 'anonymous';
+      return (
+        '<' + name + '>' + summarize(value.props.children) + '</' + name + '>'
+      );
+    }
+    if (value.$$typeof === Symbol.for('react.lazy')) {
+      const payload = value._payload;
+      if (payload.status === 'fulfilled') {
+        return 'lazy(' + summarize(payload.value) + ')';
+      }
+      if (payload.status === 'rejected') {
+        return 'lazy(rejected: ' + payload.reason.message + ')';
+      }
+      return 'lazy(' + payload.status + ')';
+    }
+    if (typeof value.then === 'function') {
+      if (value.status === 'fulfilled') {
+        return 'promise(' + summarize(value.value) + ')';
+      }
+      if (value.status === 'rejected') {
+        return 'promise(rejected: ' + value.reason.message + ')';
+      }
+      return 'promise(' + value.status + ')';
+    }
+    return JSON.stringify(value);
+  }
+
+  async function runSeed(seed) {
+    const rand = Random.create('flight-fuzz-' + seed);
+    const program = createProgram(rand);
+    const componentRoots = new Map();
+    const componentCreators = new Map();
+    const {makeComponent} = buildComponents(
+      rand,
+      program,
+      componentRoots,
+      componentCreators,
+    );
+
+    // Resolve a seeded subset of the module-scope data before rendering
+    // starts, so some awaits hit promises that settled before the request
+    // existed.
+    const preResolve = rand.intBetween(0, program.pool.length - 1);
+    for (let i = 0; i < preResolve; i++) {
+      const entry = program.pending.splice(0, 1)[0];
+      await entry.io();
+      entry.settle();
+      await program.pool[i];
+    }
+
+    // Most seeds render one root; some render two interleaved. Some abort
+    // the first render partway through.
+    const concurrentRenders = rand.intBetween(0, 3) === 0 ? 2 : 1;
+    const abortAfter = rand.intBetween(0, 5) === 0 ? rand.intBetween(2, 8) : -1;
+    const roots = [];
+    for (let i = 0; i < concurrentRenders; i++) {
+      const Root = makeComponent(0, {
+        canThrow: abortAfter === -1,
+        rootIndex: i,
+      });
+      // Root elements are created outside any component.
+      componentCreators.set(Root.name, null);
+      roots.push(Root);
+    }
+
+    const results = [];
+    const readables = [];
+    const aborts = [];
+    roots.forEach(Root => {
+      const stream = ReactServerDOMServer.renderToPipeableStream(
+        ReactServer.createElement(Root, null),
+        {},
+        {
+          filterStackFrame,
+          onError(error) {
+            // Component bugs and aborts are part of the workload.
+            return 'digest:' + error.message;
+          },
+        },
+      );
+      aborts.push(reason => stream.abort(reason));
+      const readable = new Stream.PassThrough(streamOptions);
+      results.push(
+        ReactServerDOMClient.createFromNodeStream(
+          readable,
+          {
+            moduleMap: {},
+            moduleLoading: {},
+          },
+          // Turns on the client debug handling that feeds the performance
+          // track.
+          {replayConsoleLogs: true},
+        ),
+      );
+      readables.push(readable);
+      stream.pipe(readable);
+    });
+
+    const doneRef = {done: false};
+    const allDone = Promise.all([
+      // Roots may reject (aborts, a throwing root component); the driver
+      // still needs to terminate so the rejection can surface as a value.
+      Promise.all(
+        results.map(result =>
+          result.then(
+            v => v,
+            x => x,
+          ),
+        ),
+      ),
+      Promise.all(readables.map(finishLoadingStream)),
+    ]).then(() => {
+      doneRef.done = true;
+    });
+
+    let settles = 0;
+    await drive(rand, program, doneRef, function onSettle() {
+      settles++;
+      if (settles === abortAfter) {
+        aborts[0](new Error('fuzz aborted'));
+      }
+    });
+    await allDone;
+
+    const output = [];
+    for (let i = 0; i < results.length; i++) {
+      let value;
+      try {
+        value = await results[i];
+      } catch (x) {
+        output.push({value: 'root rejected: ' + x.message, debugInfo: []});
+        continue;
+      }
+      output.push({
+        value: summarize(value),
+        debugInfo: collectDebugInfo(value),
+      });
+    }
+    // The client flushes the performance track on a 100ms timer after the
+    // last pending chunk resolves. Wait it out so the flush happens during
+    // this test instead of during whatever runs next.
+    await new Promise(resolve => setTimeout(resolve, 150));
+
+    return output;
+  }
+
+  // FUZZ_TEST_SEED reruns or explores any seed: every check is computed from
+  // what the seed's program actually did, so novel seeds verify like
+  // committed ones.
+  const seeds = [];
+  if (ONLY_SEED !== null) {
+    seeds.push(ONLY_SEED);
+  } else {
+    for (let seed = 0; seed < NUM_SEEDS; seed++) {
+      seeds.push(seed);
+    }
+  }
+  seeds.forEach(seed => {
+    it(`produces stable async debug info (seed ${seed})`, async () => {
+      // Render unconditionally so we catch any production crashes
+      await runSeed(seed);
+    });
+  });
+});


### PR DESCRIPTION
I wanted to tweak some things there but I'm nervous without more coverage so I thought why not add a fuzzer.

So I asked Claude to build me one.

This adds a fuzzer for the async debug info tracking, seeded like our other fuzzers. Each seed builds a random Flight tree: components `await`ing some data, `cache()`, waterfalls, `Promise.all`, promise props, elements rendered by a different component than created them (sometimes deduped across two locations), data preloaded before the request; some seeds abort, throw in a subtree, or interleave two renders; there are also a few userland thenables and Promise subclasses. The debug info is checked against what each seed's program actually did.

## Details

- Each leaf does real I/O (a timer or an fs read) because IO entries only come from real async resources. To keep this deterministic, the driver first waits for everything the render has scheduled to finish, then runs the leaf's I/O while nothing else is pending, then resolves the leaf — so how long the I/O takes can't change what order anything runs in.
- The generator records which component created each element and invoked each data source, which real IO backs each leaf and what it resolves to, and the driver records the order it settled things in. The emitted debug info has to agree:
  - Owner chains equal the recorded creator chains, all the way up. When two renders run at once, debug info from one render never claims a component or IO from the other — that would mean the tracking mixed up which request an operation belonged to.
  - Recorded values equal what the leaf resolved to (values over the 1MB limit arrive as the omission placeholder).
  - An IO backed by a timer never carries a file-reading stack, and vice versa.
  - IO end times are ordered the way the driver settled things.
  - Every leaf a component directly fetched and settled shows up in that render's debug info. The exceptions are enumerated in the test with reasons (combinators only attribute the IO that unblocked them, promise props dedupe into the parent's await, and so on).
  - The same IO appears at most once per awaiting component, so accumulation fails immediately.
  - Time rows are monotonic, IO never ends before it starts, and IO with a stack has a name.
- We record `performance.measure` and check that every span has finite bounds, non-negative width, and a track.
- The fuzzer runs in prod too, but without the checks, to catch crashes.

## Follow-ups

Found when running this:

- In DEV, calling `.then()` without a rejection handler on a chunk that holds a rejected value causes an unhandled rejection that can't be caught anywhere. Debug info for caught rejections hits this on most seeds. The first commit fixes our test util's instance, but the proper fix is TODO.
- I/O started with `fs.readFile` (callback form) before the request is attributed one stack frame too deep, naming the IO entry after the wrong frame. Fixed in the PR stacked on this one.
- An element prop that throws on unexpected property access (like a `ClientReference` proxy) corrupts the component's data chunk on the client. TODO.

These are fixed in https://github.com/react/react/pull/37130.