### PR TITLE
[DevTools] Deduplicate error reporting

### DIFF
--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -12,6 +12,7 @@ import {flushSync} from 'react-dom';
 import {createRoot} from 'react-dom/client';
 import Bridge from 'react-devtools-shared/src/bridge';
 import Store from 'react-devtools-shared/src/devtools/store';
+import {subscribeToStoreErrors} from 'react-devtools-shared/src/devtools/storeErrorLogger';
 import {getSavedComponentFilters} from 'react-devtools-shared/src/utils';
 import {registerDevToolsEventLogger} from 'react-devtools-shared/src/registerDevToolsEventLogger';
 import {Server} from 'ws';
@@ -209,8 +210,14 @@ function onError({code, message}: $FlowFixMe) {
 
 function openProfiler() {
   // Mocked up bridge and store to allow the DevTools to be rendered
-  bridge = new Bridge({listen: () => () => {}, send: () => {}});
-  store = new Store(bridge, {});
+  const profilerBridge: FrontendBridge = new Bridge({
+    listen: () => () => {},
+    send: () => {},
+  });
+  const profilerStore = new Store(profilerBridge, {});
+  bridge = profilerBridge;
+  store = profilerStore;
+  subscribeToStoreErrors(profilerStore, profilerBridge);
 
   // Ensure the Profiler tab is shown initially.
   localStorageSetItem(
@@ -276,6 +283,7 @@ function initialize(socket: WebSocket) {
     supportsTraceUpdates: true,
     supportsClickToInspect: true,
   });
+  subscribeToStoreErrors(store, bridge as any as FrontendBridge);
 
   log('Connected');
   statusListener('DevTools initialized.', 'devtools-connected');

--- a/packages/react-devtools-extensions/src/main/index.js
+++ b/packages/react-devtools-extensions/src/main/index.js
@@ -15,6 +15,7 @@ import {flushSync} from 'react-dom';
 import {createRoot} from 'react-dom/client';
 import Bridge from 'react-devtools-shared/src/bridge';
 import Store from 'react-devtools-shared/src/devtools/store';
+import {subscribeToStoreErrors} from 'react-devtools-shared/src/devtools/storeErrorLogger';
 import {getBrowserTheme} from '../utils';
 import {
   localStorageGetItem,
@@ -245,6 +246,7 @@ function createBridgeAndStore() {
     supportsInspectMatchingDOMElement: true,
     supportsClickToInspect: true,
   });
+  subscribeToStoreErrors(store, bridge);
 
   store.addListener('settingsUpdated', (hookSettings, componentFilters) => {
     chrome.storage.local.set({...hookSettings, componentFilters});

--- a/packages/react-devtools-fusebox/src/frontend.js
+++ b/packages/react-devtools-fusebox/src/frontend.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 import {createRoot} from 'react-dom/client';
 import Bridge from 'react-devtools-shared/src/bridge';
 import Store from 'react-devtools-shared/src/devtools/store';
+import {subscribeToStoreErrors} from 'react-devtools-shared/src/devtools/storeErrorLogger';
 import DevTools from 'react-devtools-shared/src/devtools/views/DevTools';
 
 import type {
@@ -36,12 +37,14 @@ export function createBridge(wall?: Wall): FrontendBridge {
 }
 
 export function createStore(bridge: FrontendBridge, config?: Config): Store {
-  return new Store(bridge, {
+  const store = new Store(bridge, {
     checkBridgeProtocolCompatibility: true,
     supportsTraceUpdates: true,
     supportsClickToInspect: true,
     ...config,
   });
+  subscribeToStoreErrors(store, bridge);
+  return store;
 }
 
 type InitializationOptions = {

--- a/packages/react-devtools-inline/src/frontend.js
+++ b/packages/react-devtools-inline/src/frontend.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {forwardRef} from 'react';
 import Bridge from 'react-devtools-shared/src/bridge';
 import Store from 'react-devtools-shared/src/devtools/store';
+import {subscribeToStoreErrors} from 'react-devtools-shared/src/devtools/storeErrorLogger';
 import DevTools from 'react-devtools-shared/src/devtools/views/DevTools';
 import {getSavedComponentFilters} from 'react-devtools-shared/src/utils';
 
@@ -13,12 +14,14 @@ import type {Props} from 'react-devtools-shared/src/devtools/views/DevTools';
 import type {Config} from 'react-devtools-shared/src/devtools/store';
 
 export function createStore(bridge: FrontendBridge, config?: Config): Store {
-  return new Store(bridge, {
+  const store = new Store(bridge, {
     checkBridgeProtocolCompatibility: true,
     supportsTraceUpdates: true,
     supportsTimeline: true,
     ...config,
   });
+  subscribeToStoreErrors(store, bridge);
+  return store;
 }
 
 export function createBridge(contentWindow: any, wall?: Wall): FrontendBridge {

--- a/packages/react-devtools-shared/src/Logger.js
+++ b/packages/react-devtools-shared/src/Logger.js
@@ -81,6 +81,31 @@ export const logEvent: LogFunction =
       }
     : function logEvent() {};
 
+export function logErrorEvent(
+  error: mixed,
+  componentStack: string | null,
+): void {
+  const errorMessage =
+    typeof error === 'object' &&
+    error !== null &&
+    typeof error.message === 'string'
+      ? error.message
+      : null;
+  const errorStack =
+    typeof error === 'object' &&
+    error !== null &&
+    typeof error.stack === 'string'
+      ? error.stack
+      : null;
+
+  logEvent({
+    event_name: 'error',
+    error_message: errorMessage,
+    error_stack: errorStack,
+    error_component_stack: componentStack,
+  });
+}
+
 export const registerEventLogger: (logFunction: LogFunction) => () => void =
   enableLogger === true
     ? function registerEventLogger(logFunction: LogFunction): () => void {

--- a/packages/react-devtools-shared/src/__tests__/errorReporting-test.js
+++ b/packages/react-devtools-shared/src/__tests__/errorReporting-test.js
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {getVersionedRenderImplementation} from './utils';
+
+jest.mock('react-devtools-feature-flags', () => ({
+  ...jest.requireActual('react-devtools-feature-flags'),
+  enableLogger: true,
+}));
+
+describe('error reporting', () => {
+  let React;
+  let act;
+
+  beforeEach(() => {
+    React = require('react');
+    act = require('./utils').act;
+  });
+
+  const {getContainer, render, unmount} = getVersionedRenderImplementation();
+
+  it('reports a Store error before the frontend mounts', () => {
+    const {registerEventLogger} = require('react-devtools-shared/src/Logger');
+    const {
+      subscribeToStoreErrors,
+    } = require('react-devtools-shared/src/devtools/storeErrorLogger');
+    const eventLogger = jest.fn();
+    const unregisterEventLogger = registerEventLogger(eventLogger);
+    const unsubscribeFromStoreErrors = subscribeToStoreErrors(
+      global.store,
+      global.bridge,
+    );
+    const error = new Error('Initial render error');
+
+    try {
+      expect(() => global.store._throwAndEmitError(error)).toThrow(error);
+      expect(eventLogger).toHaveBeenCalledTimes(1);
+      expect(eventLogger).toHaveBeenCalledWith({
+        event_name: 'error',
+        error_message: error.message,
+        error_stack: error.stack,
+        error_component_stack: null,
+      });
+    } finally {
+      unsubscribeFromStoreErrors();
+      unregisterEventLogger();
+    }
+  });
+
+  it('reports a Store error once when multiple error boundaries observe it', () => {
+    const {registerEventLogger} = require('react-devtools-shared/src/Logger');
+    const ErrorBoundary =
+      require('react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary').default;
+    const {
+      subscribeToStoreErrors,
+    } = require('react-devtools-shared/src/devtools/storeErrorLogger');
+    const store = global.store;
+    const eventLogger = jest.fn();
+    const unregisterEventLogger = registerEventLogger(eventLogger);
+    const unsubscribeFromStoreErrors = subscribeToStoreErrors(
+      store,
+      global.bridge,
+    );
+
+    act(() => {
+      render(
+        <>
+          <ErrorBoundary store={store}>First boundary</ErrorBoundary>
+          <ErrorBoundary store={store}>Second boundary</ErrorBoundary>
+          <ErrorBoundary store={store}>Third boundary</ErrorBoundary>
+        </>,
+      );
+    });
+
+    const error = new Error('Store error');
+    try {
+      act(() => {
+        expect(() => store._throwAndEmitError(error)).toThrow(error);
+      });
+
+      expect(eventLogger).toHaveBeenCalledTimes(1);
+      expect(eventLogger).toHaveBeenCalledWith({
+        event_name: 'error',
+        error_message: error.message,
+        error_stack: error.stack,
+        error_component_stack: null,
+      });
+      expect(
+        getContainer().textContent.match(/Uncaught Error: Store error/g),
+      ).toHaveLength(3);
+    } finally {
+      unsubscribeFromStoreErrors();
+      unregisterEventLogger();
+      act(() => unmount());
+    }
+  });
+
+  it('registers the event logger once while its iframe is loading', () => {
+    const Logger = require('react-devtools-shared/src/Logger');
+    const registerEventLogger = jest.spyOn(Logger, 'registerEventLogger');
+    const loggingURL = 'https://example.com/react-devtools-logging';
+    const previousLoggingURL = process.env.LOGGING_URL;
+    process.env.LOGGING_URL = loggingURL;
+
+    try {
+      const {
+        registerDevToolsEventLogger,
+      } = require('react-devtools-shared/src/registerDevToolsEventLogger');
+
+      registerDevToolsEventLogger('test');
+      registerDevToolsEventLogger('test');
+
+      expect(registerEventLogger).toHaveBeenCalledTimes(1);
+      expect(
+        document.querySelectorAll(`iframe[src="${loggingURL}"]`),
+      ).toHaveLength(1);
+    } finally {
+      registerEventLogger.mockRestore();
+      if (previousLoggingURL === undefined) {
+        delete process.env.LOGGING_URL;
+      } else {
+        process.env.LOGGING_URL = previousLoggingURL;
+      }
+      document
+        .querySelectorAll(`iframe[src="${loggingURL}"]`)
+        .forEach(iframe => iframe.remove());
+    }
+  });
+
+  it('normalizes values that are not Error objects', () => {
+    const {
+      logErrorEvent,
+      registerEventLogger,
+    } = require('react-devtools-shared/src/Logger');
+    const eventLogger = jest.fn();
+    const unregisterEventLogger = registerEventLogger(eventLogger);
+
+    try {
+      logErrorEvent(null, null);
+      logErrorEvent({message: 42, stack: {}}, null);
+
+      expect(eventLogger).toHaveBeenNthCalledWith(1, {
+        event_name: 'error',
+        error_message: null,
+        error_stack: null,
+        error_component_stack: null,
+      });
+      expect(eventLogger).toHaveBeenNthCalledWith(2, {
+        event_name: 'error',
+        error_message: null,
+        error_stack: null,
+        error_component_stack: null,
+      });
+    } finally {
+      unregisterEventLogger();
+    }
+  });
+});

--- a/packages/react-devtools-shared/src/devtools/storeErrorLogger.js
+++ b/packages/react-devtools-shared/src/devtools/storeErrorLogger.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type Store from './store';
+import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
+
+import {logErrorEvent} from 'react-devtools-shared/src/Logger';
+
+export function subscribeToStoreErrors(
+  store: Store,
+  bridge: FrontendBridge,
+): () => void {
+  const onError = (error: Error) => logErrorEvent(error, null);
+  let isSubscribed = true;
+
+  const unsubscribe = () => {
+    if (isSubscribed) {
+      isSubscribed = false;
+      store.removeListener('error', onError);
+      bridge.removeListener('shutdown', unsubscribe);
+    }
+  };
+
+  store.addListener('error', onError);
+  bridge.addListener('shutdown', unsubscribe);
+  return unsubscribe;
+}

--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
@@ -20,7 +20,7 @@ import UnsupportedBridgeOperationError from 'react-devtools-shared/src/Unsupport
 import TimeoutError from 'react-devtools-shared/src/errors/TimeoutError';
 import UserError from 'react-devtools-shared/src/errors/UserError';
 import UnknownHookError from 'react-devtools-shared/src/errors/UnknownHookError';
-import {logEvent} from 'react-devtools-shared/src/Logger';
+import {logErrorEvent} from 'react-devtools-shared/src/Logger';
 
 type Props = {
   children: React$Node,
@@ -97,10 +97,9 @@ export default class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: any, {componentStack}: any) {
-    this._logError(error, componentStack);
-    this.setState({
-      componentStack,
-    });
+    // This is an error trown during render, not a Store error
+    logErrorEvent(error, componentStack);
+    this.setState({componentStack});
   }
 
   componentDidMount() {
@@ -206,18 +205,6 @@ export default class ErrorBoundary extends Component<Props, State> {
     return children;
   }
 
-  _logError: (error: any, componentStack: string | null) => void = (
-    error,
-    componentStack,
-  ) => {
-    logEvent({
-      event_name: 'error',
-      error_message: error.message ?? null,
-      error_stack: error.stack ?? null,
-      error_component_stack: componentStack ?? null,
-    });
-  };
-
   _dismissError: () => void = () => {
     const onBeforeDismissCallback = this.props.onBeforeDismissCallback;
     if (typeof onBeforeDismissCallback === 'function') {
@@ -229,7 +216,6 @@ export default class ErrorBoundary extends Component<Props, State> {
 
   _onStoreError: (error: Error) => void = error => {
     if (!this.state.hasError) {
-      this._logError(error, null);
       this.setState({
         ...ErrorBoundary.getDerivedStateFromError(error),
         canDismiss: true,

--- a/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
+++ b/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
@@ -15,6 +15,7 @@ import {enableLogger} from 'react-devtools-feature-flags';
 let currentLoggingIFrame = null;
 let currentSessionId = null;
 let missedEvents: Array<LoggerEvent> = [];
+let hasRegisteredEventLogger = false;
 
 type LoggerContext = {
   page_url: ?string,
@@ -72,8 +73,9 @@ export function registerDevToolsEventLogger(
       typeof loggingUrl === 'string' &&
       loggingUrl.length > 0 &&
       body != null &&
-      currentLoggingIFrame == null
+      !hasRegisteredEventLogger
     ) {
+      hasRegisteredEventLogger = true;
       registerEventLogger(logEvent);
       currentSessionId = window.crypto.randomUUID();
 


### PR DESCRIPTION
Previously, every instance of ErrorBoundary, which wraps every custom panel in extension, was subscribing to errors from the Store. This would report the same error for every mounted panel.

ErrorBoundary now only intercepts render-time errors, and Store errors are captured and reported in an external subscription at the place where Store is created.