### PR TITLE
Add ReactDOM `browser()` API

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -35,6 +35,7 @@ import {
 import {
   REACT_MEMO_CACHE_SENTINEL,
   REACT_CONTEXT_TYPE,
+  REACT_RECOVERABLE_TYPE,
 } from 'shared/ReactSymbols';
 import hasOwnProperty from 'shared/hasOwnProperty';
 
@@ -110,6 +111,11 @@ function getPrimitiveStackCache(): Map<string, Array<any>> {
           $$typeof: REACT_CONTEXT_TYPE,
           _currentValue: null,
         } as any);
+        const recoverable = new Error();
+        Object.defineProperty(recoverable, '$$typeof', {
+          value: REACT_RECOVERABLE_TYPE,
+        });
+        Dispatcher.use(recoverable as any);
         Dispatcher.use({
           then() {},
           status: 'fulfilled',
@@ -240,6 +246,16 @@ function use<T>(usable: Usable<T>): T {
         dispatcherHookName: 'Use',
       });
       throw SuspenseException;
+    } else if (usable.$$typeof === REACT_RECOVERABLE_TYPE) {
+      hookLog.push({
+        displayName: null,
+        primitive: 'Recoverable',
+        stackError: new Error(),
+        value: undefined,
+        debugInfo: null,
+        dispatcherHookName: 'Use',
+      });
+      return undefined as any;
     } else if (usable.$$typeof === REACT_CONTEXT_TYPE) {
       const context: ReactContext<T> = usable as any;
       const value = readContext(context);

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -112,7 +112,7 @@ function getPrimitiveStackCache(): Map<string, Array<any>> {
           _currentValue: null,
         } as any);
         const recoverable = new Error();
-        Object.defineProperty(recoverable, '$$typeof', {
+        Object.defineProperty(recoverable as any, '$$typeof', {
           value: REACT_RECOVERABLE_TYPE,
         });
         Dispatcher.use(recoverable as any);

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -4707,7 +4707,7 @@ export function writeStartClientRenderedSuspenseBoundary(
     startClientRenderedSuspenseBoundary,
   );
   writeChunk(destination, clientRenderedSuspenseBoundaryError1);
-  if (errorDigest) {
+  if (errorDigest != null) {
     writeChunk(destination, clientRenderedSuspenseBoundaryError1A);
     writeChunk(destination, stringToChunk(escapeTextForBrowser(errorDigest)));
     writeChunk(
@@ -5131,6 +5131,7 @@ const clientRenderScript1Full = stringToPrecomputedChunk(
 const clientRenderScript1Partial = stringToPrecomputedChunk('$RX("');
 const clientRenderScript1A = stringToPrecomputedChunk('"');
 const clientRenderErrorScriptArgInterstitial = stringToPrecomputedChunk(',');
+const clientRenderErrorScriptNull = stringToPrecomputedChunk('null');
 const clientRenderScriptEnd = stringToPrecomputedChunk(')</script>');
 
 const clientRenderData1 = stringToPrecomputedChunk(
@@ -5182,21 +5183,27 @@ export function writeClientRenderBoundaryInstruction(
     writeChunk(destination, clientRenderScript1A);
   }
 
-  if (errorDigest || errorMessage || errorStack || errorComponentStack) {
+  if (
+    errorDigest != null ||
+    errorMessage ||
+    errorStack ||
+    errorComponentStack
+  ) {
     if (scriptFormat) {
-      // ,"JSONString"
+      // ,null or ,"JSONString"
       writeChunk(destination, clientRenderErrorScriptArgInterstitial);
-      writeChunk(
-        destination,
-        stringToChunk(escapeJSStringsForInstructionScripts(errorDigest || '')),
-      );
-    } else {
+      if (errorDigest == null) {
+        writeChunk(destination, clientRenderErrorScriptNull);
+      } else {
+        writeChunk(
+          destination,
+          stringToChunk(escapeJSStringsForInstructionScripts(errorDigest)),
+        );
+      }
+    } else if (errorDigest != null) {
       // " data-dgst="HTMLString
       writeChunk(destination, clientRenderData2);
-      writeChunk(
-        destination,
-        stringToChunk(escapeTextForBrowser(errorDigest || '')),
-      );
+      writeChunk(destination, stringToChunk(escapeTextForBrowser(errorDigest)));
     }
   }
   if (errorMessage || errorStack || errorComponentStack) {

--- a/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetInlineCodeStrings.js
+++ b/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetInlineCodeStrings.js
@@ -4,7 +4,7 @@
 export const markShellTime =
   'requestAnimationFrame(function(){$RT=performance.now()});';
 export const clientRenderBoundary =
-  '$RX=function(b,c,d,e,f){var a=document.getElementById(b);a&&(b=a.previousSibling,b.data="$!",a=a.dataset,c&&(a.dgst=c),d&&(a.msg=d),e&&(a.stck=e),f&&(a.cstck=f),b._reactRetry&&b._reactRetry())};';
+  '$RX=function(b,c,d,e,f){var a=document.getElementById(b);a&&(b=a.previousSibling,b.data="$!",a=a.dataset,null!=c&&(a.dgst=c),d&&(a.msg=d),e&&(a.stck=e),f&&(a.cstck=f),b._reactRetry&&b._reactRetry())};';
 export const completeBoundary =
   '$RB=[];$RV=function(a){$RT=performance.now();for(var b=0;b<a.length;b+=2){var c=a[b],e=a[b+1];null!==e.parentNode&&e.parentNode.removeChild(e);var f=c.parentNode;if(f){var g=c.previousSibling,h=0;do{if(c&&8===c.nodeType){var d=c.data;if("/$"===d||"/&"===d)if(0===h)break;else h--;else"$"!==d&&"$?"!==d&&"$~"!==d&&"$!"!==d&&"&"!==d||h++}d=c.nextSibling;f.removeChild(c);c=d}while(c);for(;e.firstChild;)f.insertBefore(e.firstChild,c);g.data="$";g._reactRetry&&requestAnimationFrame(g._reactRetry)}}a.length=0};\n$RC=function(a,b){if(b=document.getElementById(b))(a=document.getElementById(a))?(a.previousSibling.data="$~",$RB.push(a,b),2===$RB.length&&("number"!==typeof $RT?requestAnimationFrame($RV.bind(null,$RB)):(a=performance.now(),setTimeout($RV.bind(null,$RB),2300>a&&2E3<a?2300-a:$RT+300-a)))):b.parentNode.removeChild(b)};';
 export const completeBoundaryUpgradeToViewTransitions =

--- a/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetShared.js
+++ b/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetShared.js
@@ -395,7 +395,7 @@ export function clientRenderBoundary(
   suspenseNode.data = SUSPENSE_FALLBACK_START_DATA;
   // assign error metadata to first sibling
   const dataset = suspenseIdNode.dataset;
-  if (errorDigest) dataset['dgst'] = errorDigest;
+  if (errorDigest != null) dataset['dgst'] = errorDigest;
   if (errorMsg) dataset['msg'] = errorMsg;
   if (errorStack) dataset['stck'] = errorStack;
   if (errorComponentStack) dataset['cstck'] = errorComponentStack;

--- a/packages/react-dom/index.js
+++ b/packages/react-dom/index.js
@@ -9,6 +9,7 @@
 
 export {default as __DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE} from './src/ReactDOMSharedInternals';
 export {
+  browser,
   createPortal,
   flushSync,
   prefetchDNS,

--- a/packages/react-dom/src/ReactDOMFB.js
+++ b/packages/react-dom/src/ReactDOMFB.js
@@ -21,6 +21,7 @@ Object.assign(Internals as any, {
 export {Internals as __DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE};
 
 export {
+  browser,
   createPortal,
   flushSync,
   unstable_createEventHandle,

--- a/packages/react-dom/src/ReactDOMFB.modern.js
+++ b/packages/react-dom/src/ReactDOMFB.modern.js
@@ -10,6 +10,7 @@
 export {default as __DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE} from './ReactDOMSharedInternalsFB';
 
 export {
+  browser,
   createPortal,
   flushSync,
   unstable_batchedUpdates,

--- a/packages/react-dom/src/__tests__/ReactDOMBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMBrowser-test.js
@@ -14,6 +14,7 @@ describe('ReactDOM.browser', () => {
     jest.resetModules();
   });
 
+  // @gate enableBrowserAPI
   it('can create browser-only content before the browser renderer is initialized', async () => {
     const React = require('react');
     const ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactDOMBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMBrowser-test.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+describe('ReactDOM.browser', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('can create browser-only content before the browser renderer is initialized', async () => {
+    const React = require('react');
+    const ReactDOM = require('react-dom');
+    const browserOnly = ReactDOM.browser();
+    const ReactDOMClient = require('react-dom/client');
+    const {act} = require('internal-test-utils');
+
+    function BrowserOnly() {
+      React.use(browserOnly);
+      return <span>Browser</span>;
+    }
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => {
+      root.render(
+        <React.Suspense fallback={<span>Fallback</span>}>
+          <BrowserOnly />
+        </React.Suspense>,
+      );
+    });
+    expect(container.innerHTML).toBe('<span>Browser</span>');
+  });
+});

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -447,15 +447,6 @@ describe('ReactDOMFizzServer', () => {
         <span>Fallback</span>
       </div>,
     );
-    if (__DEV__) {
-      const boundary = container.querySelector('template');
-      expect(boundary.dataset.msg).toBe(
-        'Switched to client rendering because a component requested it.',
-      );
-      expect(boundary.dataset.cstck).toContain('at BrowserOnly');
-      expect(boundary.dataset.stck).toBeUndefined();
-    }
-
     const recoverableErrors = [];
     ReactDOMClient.hydrateRoot(container, <App />, {
       onRecoverableError(error) {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -406,6 +406,7 @@ describe('ReactDOMFizzServer', () => {
     );
   }
 
+  // @gate enableBrowserAPI
   it('can opt a component into browser-only rendering', async () => {
     let resolveBrowserText;
     const browserText = new Promise(resolve => {
@@ -482,6 +483,7 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
+  // @gate enableBrowserAPI
   it('can opt a component into browser-only rendering after streaming the fallback', async () => {
     let resolveServerReady;
     const serverReady = new Promise(resolve => {
@@ -542,6 +544,7 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
+  // @gate enableBrowserAPI
   it('errors if browser-only content is rendered outside Suspense', async () => {
     function createBrowserValue() {
       return ReactDOM.browser();
@@ -586,6 +589,7 @@ describe('ReactDOMFizzServer', () => {
     expect(reportedErrors).toEqual([shellError]);
   });
 
+  // @gate enableBrowserAPI
   it('can abort all pending boundaries into browser-only rendering', async () => {
     const never = new Promise(() => {});
     let isClient = false;
@@ -656,6 +660,7 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
+  // @gate enableBrowserAPI
   it('errors if aborted with browser() before the shell completes', async () => {
     const never = new Promise(() => {});
     const browserValue = ReactDOM.browser();
@@ -699,6 +704,7 @@ describe('ReactDOMFizzServer', () => {
     expect(reportedErrors).toEqual([shellError]);
   });
 
+  // @gate enableBrowserAPI
   it('reports the browser value if it is thrown instead of passed to use', async () => {
     const browserValue = ReactDOM.browser();
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -446,12 +446,14 @@ describe('ReactDOMFizzServer', () => {
         <span>Fallback</span>
       </div>,
     );
-    const boundary = container.querySelector('template');
-    expect(boundary.dataset.msg).toBe(
-      'Switched to client rendering because a component requested it.',
-    );
-    expect(boundary.dataset.cstck).toContain('at BrowserOnly');
-    expect(boundary.dataset.stck).toBeUndefined();
+    if (__DEV__) {
+      const boundary = container.querySelector('template');
+      expect(boundary.dataset.msg).toBe(
+        'Switched to client rendering because a component requested it.',
+      );
+      expect(boundary.dataset.cstck).toContain('at BrowserOnly');
+      expect(boundary.dataset.stck).toBeUndefined();
+    }
 
     const recoverableErrors = [];
     ReactDOMClient.hydrateRoot(container, <App />, {
@@ -580,6 +582,119 @@ describe('ReactDOMFizzServer', () => {
     expect(shellError.cause.message).toContain(
       '`use(browser())` can only be used inside a `<Suspense>` boundary',
     );
+    expect(shellReady).toBe(false);
+    expect(reportedErrors).toEqual([shellError]);
+  });
+
+  it('can abort all pending boundaries into browser-only rendering', async () => {
+    const never = new Promise(() => {});
+    let isClient = false;
+
+    function Pending({children}) {
+      if (!isClient) {
+        use(never);
+      }
+      return <span>{children}</span>;
+    }
+
+    function App() {
+      return (
+        <div>
+          <span>Shell</span>
+          <Suspense fallback={<span>Loading A</span>}>
+            <Pending>A</Pending>
+          </Suspense>
+          <Suspense fallback={<span>Loading B</span>}>
+            <Pending>B</Pending>
+          </Suspense>
+        </div>
+      );
+    }
+
+    const serverErrors = [];
+    let abort;
+    await act(() => {
+      const controls = renderToPipeableStream(<App />, {
+        onError(error) {
+          serverErrors.push(error);
+        },
+      });
+      abort = controls.abort;
+      controls.pipe(writable);
+    });
+
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <span>Shell</span>
+        <span>Loading A</span>
+        <span>Loading B</span>
+      </div>,
+    );
+
+    await act(() => {
+      abort(ReactDOM.browser());
+    });
+
+    expect(serverErrors).toEqual([]);
+
+    isClient = true;
+    const recoverableErrors = [];
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        recoverableErrors.push(error);
+      },
+    });
+    await waitForAll([]);
+
+    expect(recoverableErrors).toEqual([]);
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <span>Shell</span>
+        <span>A</span>
+        <span>B</span>
+      </div>,
+    );
+  });
+
+  it('errors if aborted with browser() before the shell completes', async () => {
+    const never = new Promise(() => {});
+    const browserValue = ReactDOM.browser();
+
+    function PendingRoot() {
+      use(never);
+      return <span>Root</span>;
+    }
+
+    const reportedErrors = [];
+    let shellReady = false;
+    let shellError;
+    let abort;
+    await act(() => {
+      const controls = renderToPipeableStream(<PendingRoot />, {
+        onError(error) {
+          reportedErrors.push(error);
+        },
+        onShellReady() {
+          shellReady = true;
+        },
+        onShellError(error) {
+          shellError = error;
+        },
+      });
+      abort = controls.abort;
+    });
+
+    await act(() => {
+      abort(browserValue);
+    });
+
+    expect(shellError).toBeInstanceOf(Error);
+    expect(shellError.message).toBe(
+      'The server render could not complete because client rendering was ' +
+        "requested outside a Suspense boundary. See this error's cause for " +
+        'additional details.',
+    );
+    expect(shellError.cause).toBe(browserValue);
     expect(shellReady).toBe(false);
     expect(reportedErrors).toEqual([shellError]);
   });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -406,6 +406,261 @@ describe('ReactDOMFizzServer', () => {
     );
   }
 
+  it('can opt a component into browser-only rendering', async () => {
+    let resolveBrowserText;
+    const browserText = new Promise(resolve => {
+      resolveBrowserText = resolve;
+    });
+    const browserOnly = ReactDOM.browser();
+
+    function BrowserOnly() {
+      use(browserOnly);
+      const text = use(browserText);
+      Scheduler.log(text);
+      return <span>{text}</span>;
+    }
+
+    function App() {
+      return (
+        <div>
+          <Suspense fallback={<span>Fallback</span>}>
+            <BrowserOnly />
+          </Suspense>
+        </div>
+      );
+    }
+
+    const serverErrors = [];
+    await act(() => {
+      const {pipe} = renderToPipeableStream(<App />, {
+        onError(error) {
+          serverErrors.push(error);
+        },
+      });
+      pipe(writable);
+    });
+
+    expect(serverErrors).toEqual([]);
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <span>Fallback</span>
+      </div>,
+    );
+    const boundary = container.querySelector('template');
+    expect(boundary.dataset.msg).toBe(
+      'Switched to client rendering because a component requested it.',
+    );
+    expect(boundary.dataset.cstck).toContain('at BrowserOnly');
+    expect(boundary.dataset.stck).toBeUndefined();
+
+    const recoverableErrors = [];
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        recoverableErrors.push(error);
+      },
+    });
+    await waitForAll([]);
+
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <span>Fallback</span>
+      </div>,
+    );
+
+    await clientAct(() => {
+      resolveBrowserText('Browser');
+    });
+    assertLog(['Browser']);
+
+    expect(recoverableErrors).toEqual([]);
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <span>Browser</span>
+      </div>,
+    );
+  });
+
+  it('can opt a component into browser-only rendering after streaming the fallback', async () => {
+    let resolveServerReady;
+    const serverReady = new Promise(resolve => {
+      resolveServerReady = resolve;
+    });
+
+    function BrowserOnly() {
+      use(serverReady);
+      use(ReactDOM.browser());
+      return <span>Browser</span>;
+    }
+
+    function App() {
+      return (
+        <div>
+          <Suspense fallback={<span>Fallback</span>}>
+            <BrowserOnly />
+          </Suspense>
+        </div>
+      );
+    }
+
+    const serverErrors = [];
+    await act(() => {
+      const {pipe} = renderToPipeableStream(<App />, {
+        onError(error) {
+          serverErrors.push(error);
+        },
+      });
+      pipe(writable);
+    });
+
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <span>Fallback</span>
+      </div>,
+    );
+
+    await act(() => {
+      resolveServerReady();
+    });
+
+    expect(serverErrors).toEqual([]);
+
+    const recoverableErrors = [];
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        recoverableErrors.push(error);
+      },
+    });
+    await waitForAll([]);
+
+    expect(recoverableErrors).toEqual([]);
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <span>Browser</span>
+      </div>,
+    );
+  });
+
+  it('errors if browser-only content is rendered outside Suspense', async () => {
+    function createBrowserValue() {
+      return ReactDOM.browser();
+    }
+    const browserValue = createBrowserValue();
+
+    function BrowserOnly() {
+      use(browserValue);
+      return <span>Browser</span>;
+    }
+
+    const reportedErrors = [];
+    let shellReady = false;
+    let shellError;
+    await act(() => {
+      renderToPipeableStream(<BrowserOnly />, {
+        onError(error) {
+          reportedErrors.push(error);
+        },
+        onShellReady() {
+          shellReady = true;
+        },
+        onShellError(error) {
+          shellError = error;
+        },
+      });
+    });
+
+    expect(shellError).toBeInstanceOf(Error);
+    expect(shellError.message).toBe(
+      'The server render could not complete because client rendering was ' +
+        "requested outside a Suspense boundary. See this error's cause for " +
+        'additional details.',
+    );
+    expect(shellError.stack).toContain('BrowserOnly');
+    expect(shellError.cause).toBe(browserValue);
+    expect(shellError.cause.stack).toContain('createBrowserValue');
+    expect(shellError.cause.message).toContain(
+      '`use(browser())` can only be used inside a `<Suspense>` boundary',
+    );
+    expect(shellReady).toBe(false);
+    expect(reportedErrors).toEqual([shellError]);
+  });
+
+  it('reports the browser value if it is thrown instead of passed to use', async () => {
+    const browserValue = ReactDOM.browser();
+
+    function BrowserOnly() {
+      throw browserValue;
+    }
+
+    const reportedErrors = [];
+    await act(() => {
+      const {pipe} = renderToPipeableStream(
+        <Suspense fallback={<span>Fallback</span>}>
+          <BrowserOnly />
+        </Suspense>,
+        {
+          onError(error) {
+            reportedErrors.push(error);
+          },
+        },
+      );
+      pipe(writable);
+    });
+
+    expect(reportedErrors).toEqual([browserValue]);
+    expect(getVisibleChildren(container)).toEqual(<span>Fallback</span>);
+  });
+
+  ['', 'BROWSER'].forEach(userDigest => {
+    it(`does not reserve the ${JSON.stringify(
+      userDigest,
+    )} user error digest for browser rendering`, async () => {
+      let isClient = false;
+      const serverError = new Error('Server error');
+
+      function ServerError() {
+        if (!isClient) {
+          throw serverError;
+        }
+        return <span>Client</span>;
+      }
+
+      function App() {
+        return (
+          <Suspense fallback={<span>Fallback</span>}>
+            <ServerError />
+          </Suspense>
+        );
+      }
+
+      const serverErrors = [];
+      await act(() => {
+        const {pipe} = renderToPipeableStream(<App />, {
+          onError(error) {
+            serverErrors.push(error);
+            return userDigest;
+          },
+        });
+        pipe(writable);
+      });
+
+      expect(serverErrors).toEqual([serverError]);
+      expect(getVisibleChildren(container)).toEqual(<span>Fallback</span>);
+
+      isClient = true;
+      const recoverableErrors = [];
+      ReactDOMClient.hydrateRoot(container, <App />, {
+        onRecoverableError(error) {
+          recoverableErrors.push(error);
+        },
+      });
+      await waitForAll([]);
+
+      expect(recoverableErrors).toHaveLength(1);
+      expect(recoverableErrors[0].digest).toBe(userDigest || undefined);
+      expect(getVisibleChildren(container)).toEqual(<span>Client</span>);
+    });
+  });
+
   it('should asynchronously load a lazy component', async () => {
     let resolveA;
     const LazyA = React.lazy(() => {

--- a/packages/react-dom/src/client/ReactDOMClientFB.js
+++ b/packages/react-dom/src/client/ReactDOMClientFB.js
@@ -28,6 +28,7 @@ import ReactVersion from 'shared/ReactVersion';
 import {ensureCorrectIsomorphicReactVersion} from '../shared/ensureCorrectIsomorphicReactVersion';
 ensureCorrectIsomorphicReactVersion();
 
+import {browser} from '../shared/ReactDOMBrowser';
 import {
   getInstanceFromNode,
   getNodeFromInstance,
@@ -125,6 +126,7 @@ function unstable_batchedUpdates<A, R>(fn: (a: A) => R, a: A): R {
 }
 
 export {
+  browser,
   createPortal,
   unstable_batchedUpdates,
   flushSync,

--- a/packages/react-dom/src/shared/ReactDOM.js
+++ b/packages/react-dom/src/shared/ReactDOM.js
@@ -28,6 +28,7 @@ import {
   useFormStatus,
   useFormState,
 } from 'react-dom-bindings/src/shared/ReactDOMFormActions';
+import {browser} from './ReactDOMBrowser';
 
 if (__DEV__) {
   if (
@@ -69,6 +70,7 @@ function createPortal(
 
 export {
   ReactVersion as version,
+  browser,
   createPortal,
   flushSync,
   batchedUpdates as unstable_batchedUpdates,

--- a/packages/react-dom/src/shared/ReactDOMBrowser.js
+++ b/packages/react-dom/src/shared/ReactDOMBrowser.js
@@ -22,7 +22,7 @@ export function browser(): ReactRecoverable {
       'component that called `use(browser())` does not have a `<Suspense>` ' +
       'boundary above it.',
   );
-  Object.defineProperty(recoverable, '$$typeof', {
+  Object.defineProperty(recoverable as any, '$$typeof', {
     value: REACT_RECOVERABLE_TYPE,
   });
   return recoverable as any;

--- a/packages/react-dom/src/shared/ReactDOMBrowser.js
+++ b/packages/react-dom/src/shared/ReactDOMBrowser.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ReactRecoverable} from 'shared/ReactTypes';
+
+import {REACT_RECOVERABLE_TYPE} from 'shared/ReactSymbols';
+
+export function browser(): ReactRecoverable {
+  // Recoverables are Errors so that a renderer can preserve the browser() call
+  // site as the cause if no downstream renderer can recover the subtree.
+  const recoverable = new Error(
+    "Recoverable Exception: This is not a real error! It's an " +
+      'implementation detail of `use(browser())` to defer rendering to the ' +
+      'browser. `use(browser())` can only be used inside a `<Suspense>` ' +
+      'boundary. If a server render errors with this as its cause, the ' +
+      'component that called `use(browser())` does not have a `<Suspense>` ' +
+      'boundary above it.',
+  );
+  Object.defineProperty(recoverable, '$$typeof', {
+    value: REACT_RECOVERABLE_TYPE,
+  });
+  return recoverable as any;
+}

--- a/packages/react-dom/src/shared/ReactDOMBrowser.js
+++ b/packages/react-dom/src/shared/ReactDOMBrowser.js
@@ -9,9 +9,10 @@
 
 import type {ReactRecoverable} from 'shared/ReactTypes';
 
+import {enableBrowserAPI} from 'shared/ReactFeatureFlags';
 import {REACT_RECOVERABLE_TYPE} from 'shared/ReactSymbols';
 
-export function browser(): ReactRecoverable {
+const browserImpl = function browser(): ReactRecoverable {
   // Recoverables are Errors so that a renderer can preserve the browser() call
   // site as the cause if no downstream renderer can recover the subtree.
   const recoverable = new Error(
@@ -26,4 +27,8 @@ export function browser(): ReactRecoverable {
     value: REACT_RECOVERABLE_TYPE,
   });
   return recoverable as any;
-}
+};
+
+export const browser: (() => ReactRecoverable) | void = enableBrowserAPI
+  ? browserImpl
+  : undefined;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -131,6 +131,7 @@ import {
   REACT_MEMO_TYPE,
   REACT_CONTEXT_TYPE,
 } from 'shared/ReactSymbols';
+import {REACT_RECOVERABLE_DIGEST} from 'shared/ReactRecoverable';
 import {setCurrentFiber} from './ReactCurrentFiber';
 import {resolveTypeForHotReloading} from './ReactFiberHotReloading';
 
@@ -3001,25 +3002,29 @@ function updateDehydratedSuspenseComponent(
         ({digest} = getSuspenseInstanceFallbackErrorDetails(suspenseInstance));
       }
 
-      let error: Error;
-      if (__DEV__ && message) {
-        // eslint-disable-next-line react-internal/prod-error-codes
-        error = new Error(message);
-      } else {
-        error = new Error(
-          'The server could not finish this Suspense boundary, likely ' +
-            'due to an error during server rendering. ' +
-            'Switched to client rendering.',
+      // This is unreachable in renderers that do not support hydration.
+      // $FlowFixMe[invalid-compare]
+      if (digest !== REACT_RECOVERABLE_DIGEST) {
+        let error: Error;
+        if (__DEV__ && message) {
+          // eslint-disable-next-line react-internal/prod-error-codes
+          error = new Error(message);
+        } else {
+          error = new Error(
+            'The server could not finish this Suspense boundary, likely ' +
+              'due to an error during server rendering. ' +
+              'Switched to client rendering.',
+          );
+        }
+        // Replace the stack with the server stack
+        error.stack = (__DEV__ && stack) || '';
+        (error as any).digest = digest;
+        const capturedValue = createCapturedValueFromError(
+          error,
+          componentStack === undefined ? null : componentStack,
         );
+        queueHydrationError(capturedValue);
       }
-      // Replace the stack with the server stack
-      error.stack = (__DEV__ && stack) || '';
-      (error as any).digest = digest;
-      const capturedValue = createCapturedValueFromError(
-        error,
-        componentStack === undefined ? null : componentStack,
-      );
-      queueHydrationError(capturedValue);
       return retrySuspenseComponentWithoutHydrating(
         current,
         workInProgress,

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -46,6 +46,7 @@ import {
 } from 'shared/ReactFeatureFlags';
 import {
   REACT_CONTEXT_TYPE,
+  REACT_RECOVERABLE_TYPE,
   REACT_MEMO_CACHE_SENTINEL,
 } from 'shared/ReactSymbols';
 
@@ -1156,6 +1157,10 @@ function use<T>(usable: Usable<T>): T {
       // This is a thenable.
       const thenable: Thenable<T> = usable as any;
       return useThenable(thenable);
+    } else if (usable.$$typeof === REACT_RECOVERABLE_TYPE) {
+      // Fiber is the final renderer, so there is no downstream host that
+      // needs to recover this subtree. Continue rendering through it.
+      return undefined as any;
     } else if (usable.$$typeof === REACT_CONTEXT_TYPE) {
       const context: ReactContext<T> = usable as any;
       return readContext(context);

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -14,6 +14,7 @@ import type {
   StartTransitionOptions,
   Thenable,
   Usable,
+  ReactRecoverable,
   ReactCustomFormAction,
   Awaited,
 } from 'shared/ReactTypes';
@@ -41,6 +42,7 @@ import {createFastHash} from './ReactServerStreamConfig';
 import is from 'shared/objectIs';
 import {
   REACT_CONTEXT_TYPE,
+  REACT_RECOVERABLE_TYPE,
   REACT_MEMO_CACHE_SENTINEL,
 } from 'shared/ReactSymbols';
 import {checkAttributeStringCoercion} from 'shared/CheckStringCoercion';
@@ -89,6 +91,18 @@ let actionStateMatchingIndex: number = -1;
 // Counts the number of use(thenable) calls in this component
 let thenableIndexCounter: number = 0;
 let thenableState: ThenableState | null = null;
+// An opaque exception that lets the Fizz work loop distinguish a recoverable
+// from an Error thrown by application code. The actual errors are stored
+// separately so this implementation detail cannot be mistaken for either
+// diagnostic if it is caught by userspace.
+export const RecoverableException: mixed = new Error(
+  "Recoverable Exception: This is not a real error! It's an implementation " +
+    'detail of `use` to interrupt the current render so a downstream ' +
+    'renderer can recover it. You must either rethrow it immediately, or move ' +
+    'the `use` call outside of the `try/catch` block. Capturing without ' +
+    'rethrowing will lead to unexpected behavior.',
+);
+let suspendedRecoverableError: Error | null = null;
 // Lazily created map of render-phase updates
 let renderPhaseUpdates: Map<UpdateQueue<any>, Update<any>> | null = null;
 // Counter to prevent infinite loops.
@@ -274,6 +288,22 @@ export function getThenableStateAfterSuspending(): null | ThenableState {
   const state = thenableState;
   thenableState = null;
   return state;
+}
+
+export function getSuspendedRecoverableError(): Error {
+  if (suspendedRecoverableError === null) {
+    throw new Error(
+      'Expected a suspended recoverable. This is a bug in React. Please file ' +
+        'an issue.',
+    );
+  }
+  const error = suspendedRecoverableError;
+  suspendedRecoverableError = null;
+  return error;
+}
+
+export function clearSuspendedRecoverableError(): void {
+  suspendedRecoverableError = null;
 }
 
 export function checkDidRenderIdHook(): boolean {
@@ -756,6 +786,20 @@ function use<T>(usable: Usable<T>): T {
       // This is a thenable.
       const thenable: Thenable<T> = usable as any;
       return unwrapThenable(thenable);
+    } else if (usable.$$typeof === REACT_RECOVERABLE_TYPE) {
+      // Fizz can defer this subtree to a downstream renderer. Like a suspended
+      // thenable, keep the actual value out of userspace and throw an opaque
+      // sentinel to unwind the stack. Capture the use() call site eagerly so
+      // that if there is no Suspense boundary, the fatal error points here and
+      // its cause points to where the recoverable was created.
+      const recoverable: ReactRecoverable = usable as any;
+      suspendedRecoverableError = new Error(
+        'The server render could not complete because client rendering was ' +
+          "requested outside a Suspense boundary. See this error's cause for " +
+          'additional details.',
+        {cause: recoverable},
+      );
+      throw RecoverableException;
     } else if (usable.$$typeof === REACT_CONTEXT_TYPE) {
       const context: ReactContext<T> = usable as any;
       return readContext(context);

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -103,6 +103,18 @@ export const RecoverableException: mixed = new Error(
     'rethrowing will lead to unexpected behavior.',
 );
 let suspendedRecoverableError: Error | null = null;
+
+export function createFatalRecoverableError(
+  recoverable: ReactRecoverable,
+): Error {
+  return new Error(
+    'The server render could not complete because client rendering was ' +
+      "requested outside a Suspense boundary. See this error's cause for " +
+      'additional details.',
+    {cause: recoverable},
+  );
+}
+
 // Lazily created map of render-phase updates
 let renderPhaseUpdates: Map<UpdateQueue<any>, Update<any>> | null = null;
 // Counter to prevent infinite loops.
@@ -793,12 +805,7 @@ function use<T>(usable: Usable<T>): T {
       // that if there is no Suspense boundary, the fatal error points here and
       // its cause points to where the recoverable was created.
       const recoverable: ReactRecoverable = usable as any;
-      suspendedRecoverableError = new Error(
-        'The server render could not complete because client rendering was ' +
-          "requested outside a Suspense boundary. See this error's cause for " +
-          'additional details.',
-        {cause: recoverable},
-      );
+      suspendedRecoverableError = createFatalRecoverableError(recoverable);
       throw RecoverableException;
     } else if (usable.$$typeof === REACT_CONTEXT_TYPE) {
       const context: ReactContext<T> = usable as any;

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1325,8 +1325,10 @@ function encodeErrorForBoundary(
   boundary.errorDigest = digest;
   if (__DEV__) {
     if (error === RecoverableException) {
-      boundary.errorMessage =
-        'Switched to client rendering because it was explicitly requested.';
+      boundary.errorMessage = wasAborted
+        ? 'Switched to client rendering because the server render was aborted ' +
+          'with a request to render on the client.'
+        : 'Switched to client rendering because a component requested it.';
       boundary.errorComponentStack = thrownInfo.componentStack;
       return;
     }
@@ -4873,7 +4875,7 @@ function finishAbortedTask(task: Task, request: Request, error: mixed): void {
           errorForBoundary,
           errorDigest,
           errorInfo,
-          !isRecoverableAbort,
+          true,
         );
       }
       request.pendingRootTasks--;
@@ -4917,7 +4919,7 @@ function finishAbortedTask(task: Task, request: Request, error: mixed): void {
         errorDigest,
         errorForBoundary,
         errorInfo,
-        !isRecoverableAbort,
+        true,
       );
 
       untrackBoundary(request, boundary);

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -28,6 +28,7 @@ import type {
   SuspenseListProps,
   SuspenseListRevealOrder,
   ReactKey,
+  ReactRecoverable,
 } from 'shared/ReactTypes';
 import type {LazyComponent as LazyComponentType} from 'react/src/ReactLazy';
 import type {
@@ -135,6 +136,7 @@ import {
   getActionStateCount,
   getActionStateMatchingIndex,
   RecoverableException,
+  createFatalRecoverableError,
   getSuspendedRecoverableError,
   clearSuspendedRecoverableError,
 } from './ReactFizzHooks';
@@ -176,6 +178,7 @@ import {
   REACT_VIEW_TRANSITION_TYPE,
   REACT_ACTIVITY_TYPE,
   REACT_OPTIMISTIC_KEY,
+  REACT_RECOVERABLE_TYPE,
 } from 'shared/ReactSymbols';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {
@@ -4802,19 +4805,43 @@ function finishAbortedTask(task: Task, request: Request, error: mixed): void {
   }
 
   const errorInfo = getThrownInfo(task.componentStack);
+  // Only abort reasons get this interpretation. Throwing a recoverable
+  // directly is still an application error; it must be passed to use() or
+  // abort() for a renderer to recover it.
+  const isRecoverableAbort =
+    typeof error === 'object' &&
+    error !== null &&
+    // $FlowFixMe[prop-missing]
+    error.$$typeof === REACT_RECOVERABLE_TYPE;
 
   if (boundary === null) {
     const replay: null | ReplaySet = task.replay;
     if (replay === null) {
       // We didn't complete the root so we have nothing to show. We can close
       // the request;
-      if (request.trackedPostpones !== null && segment !== null) {
+      if (
+        !isRecoverableAbort &&
+        request.trackedPostpones !== null &&
+        segment !== null
+      ) {
         const trackedPostpones = request.trackedPostpones;
         // We are aborting a prerender and must treat the shell as halted
         // We log the error but we still resolve the prerender
         logRecoverableError(request, error, errorInfo, task.debugTask);
         trackPostpone(request, trackedPostpones, task, segment);
         finishedTask(request, null, task.row, segment);
+      } else if (isRecoverableAbort) {
+        const recoverable: ReactRecoverable = error as any;
+        const fatalRecoverableError = createFatalRecoverableError(recoverable);
+        logRecoverableError(
+          request,
+          fatalRecoverableError,
+          errorInfo,
+          task.debugTask,
+        );
+        if (request.status !== CLOSING && request.status !== CLOSED) {
+          fatalError(request, fatalRecoverableError, errorInfo, task.debugTask);
+        }
       } else {
         logRecoverableError(request, error, errorInfo, task.debugTask);
         if (request.status !== CLOSING && request.status !== CLOSED) {
@@ -4829,21 +4856,24 @@ function finishAbortedTask(task: Task, request: Request, error: mixed): void {
       // the ReplaySet.
       replay.pendingTasks--;
       if (replay.pendingTasks === 0 && replay.nodes.length > 0) {
-        const errorDigest = logRecoverableError(
-          request,
-          error,
-          errorInfo,
-          null,
-        );
+        let errorDigest;
+        let errorForBoundary;
+        if (isRecoverableAbort) {
+          errorDigest = REACT_RECOVERABLE_DIGEST;
+          errorForBoundary = RecoverableException;
+        } else {
+          errorDigest = logRecoverableError(request, error, errorInfo, null);
+          errorForBoundary = error;
+        }
         abortRemainingReplayNodes(
           request,
           null,
           replay.nodes,
           replay.slots,
-          error,
+          errorForBoundary,
           errorDigest,
           errorInfo,
-          true,
+          !isRecoverableAbort,
         );
       }
       request.pendingRootTasks--;
@@ -4856,7 +4886,11 @@ function finishAbortedTask(task: Task, request: Request, error: mixed): void {
     // boundary the message is referring to
     const trackedPostpones = request.trackedPostpones;
     if (boundary.status !== CLIENT_RENDERED) {
-      if (trackedPostpones !== null && segment !== null) {
+      if (
+        !isRecoverableAbort &&
+        trackedPostpones !== null &&
+        segment !== null
+      ) {
         // We are aborting a prerender and must halt this boundary.
         // We treat this like other postpones during prerendering
         logRecoverableError(request, error, errorInfo, task.debugTask);
@@ -4872,14 +4906,19 @@ function finishAbortedTask(task: Task, request: Request, error: mixed): void {
       boundary.status = CLIENT_RENDERED;
       // We are aborting a render or resume which should put boundaries
       // into an explicitly client rendered state
-      const errorDigest = logRecoverableError(
-        request,
-        error,
+      const errorDigest = isRecoverableAbort
+        ? REACT_RECOVERABLE_DIGEST
+        : logRecoverableError(request, error, errorInfo, task.debugTask);
+      const errorForBoundary = isRecoverableAbort
+        ? RecoverableException
+        : error;
+      encodeErrorForBoundary(
+        boundary,
+        errorDigest,
+        errorForBoundary,
         errorInfo,
-        task.debugTask,
+        !isRecoverableAbort,
       );
-      boundary.status = CLIENT_RENDERED;
-      encodeErrorForBoundary(boundary, errorDigest, error, errorInfo, true);
 
       untrackBoundary(request, boundary);
 

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -134,6 +134,9 @@ import {
   readPreviousThenableFromState,
   getActionStateCount,
   getActionStateMatchingIndex,
+  RecoverableException,
+  getSuspendedRecoverableError,
+  clearSuspendedRecoverableError,
 } from './ReactFizzHooks';
 import {DefaultAsyncDispatcher} from './ReactFizzAsyncDispatcher';
 import {
@@ -191,6 +194,7 @@ import assign from 'shared/assign';
 import noop from 'shared/noop';
 import getComponentNameFromType from 'shared/getComponentNameFromType';
 import isArray from 'shared/isArray';
+import {REACT_RECOVERABLE_DIGEST} from 'shared/ReactRecoverable';
 import {
   SuspenseException,
   getSuspendedThenable,
@@ -1317,6 +1321,12 @@ function encodeErrorForBoundary(
 ) {
   boundary.errorDigest = digest;
   if (__DEV__) {
+    if (error === RecoverableException) {
+      boundary.errorMessage =
+        'Switched to client rendering because a component requested it.';
+      boundary.errorComponentStack = thrownInfo.componentStack;
+      return;
+    }
     let message, stack;
     // In dev we additionally encode the error message and component stack on the boundary
     if (error instanceof Error) {
@@ -1347,6 +1357,11 @@ function logRecoverableError(
   errorInfo: ThrownInfo,
   debugTask: null | ConsoleTask,
 ): ?string {
+  if (error === RecoverableException) {
+    clearSuspendedRecoverableError();
+    return REACT_RECOVERABLE_DIGEST;
+  }
+
   // If this callback errors, we intentionally let that error bubble up to become a fatal error
   // so that someone fixes the error reporting instead of hiding it.
   const onError = request.onError;
@@ -1365,7 +1380,10 @@ function logRecoverableError(
     }
     return;
   }
-  return errorDigest;
+  // An empty digest is reserved for React's internal client-render signal.
+  // Historically an empty digest was omitted from the wire format, so
+  // normalizing it to undefined preserves the existing user-space semantics.
+  return errorDigest === '' ? undefined : errorDigest;
 }
 
 function fatalError(
@@ -4524,19 +4542,34 @@ function erroredTask(
 
   request.allPendingTasks--;
 
-  // Report the error to a global handler.
   // We don't handle halts here because we only halt when prerendering and
   // when prerendering we should be finishing tasks not erroring them when
   // they halt or postpone
-  const errorDigest = logRecoverableError(request, error, errorInfo, debugTask);
   if (boundary === null) {
-    fatalError(request, error, errorInfo, debugTask);
+    // Recoverables can remain silent when a Suspense boundary lets us emit a
+    // shell and defer its content to a downstream renderer. At the root there
+    // is no shell to stream, so this is a fatal error and must be reported like
+    // any other root error.
+    if (error === RecoverableException) {
+      const useError = getSuspendedRecoverableError();
+      logRecoverableError(request, useError, errorInfo, debugTask);
+      fatalError(request, useError, errorInfo, debugTask);
+    } else {
+      logRecoverableError(request, error, errorInfo, debugTask);
+      fatalError(request, error, errorInfo, debugTask);
+    }
     // The shell fatally errored, so the render can never complete. Return before
     // the completeAll check below so we don't fire onAllReady for a render that
     // produced nothing. This mirrors finishAbortedTask, which also returns after
     // a fatalError on the root.
     return;
   } else {
+    const errorDigest = logRecoverableError(
+      request,
+      error,
+      errorInfo,
+      debugTask,
+    );
     boundary.pendingTasks--;
     if (boundary.status !== CLIENT_RENDERED) {
       boundary.status = CLIENT_RENDERED;

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1326,7 +1326,7 @@ function encodeErrorForBoundary(
   if (__DEV__) {
     if (error === RecoverableException) {
       boundary.errorMessage =
-        'Switched to client rendering because a component requested it.';
+        'Switched to client rendering because it was explicitly requested.';
       boundary.errorComponentStack = thrownInfo.componentStack;
       return;
     }

--- a/packages/react-server/src/ReactFlightHooks.js
+++ b/packages/react-server/src/ReactFlightHooks.js
@@ -151,7 +151,11 @@ function use<T>(usable: Usable<T>): T {
   }
 
   if (isClientReference(usable)) {
-    if (usable.value != null && usable.value.$$typeof === REACT_CONTEXT_TYPE) {
+    const clientReference: any = usable;
+    if (
+      clientReference.value != null &&
+      clientReference.value.$$typeof === REACT_CONTEXT_TYPE
+    ) {
       // Show a more specific message since it's a common mistake.
       throw new Error('Cannot read a Client Context from a Server Component.');
     } else {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -22,6 +22,9 @@
 // when it rolls out to prod. We should remove these as soon as possible.
 // -----------------------------------------------------------------------------
 
+// Enables the browser() API exported from react-dom.
+export const enableBrowserAPI: boolean = true;
+
 // -----------------------------------------------------------------------------
 // Land or remove (moderate effort)
 //

--- a/packages/shared/ReactRecoverable.js
+++ b/packages/shared/ReactRecoverable.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Empty digests are otherwise treated as if no digest was provided. This lets
+// React distinguish an intentional client render without reserving a
+// user-space digest value.
+export const REACT_RECOVERABLE_DIGEST = '';

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -46,6 +46,8 @@ export const REACT_VIEW_TRANSITION_TYPE: symbol = Symbol.for(
   'react.view_transition',
 );
 
+export const REACT_RECOVERABLE_TYPE: symbol = Symbol.for('react.recoverable');
+
 const MAYBE_ITERATOR_SYMBOL = Symbol.iterator;
 const FAUX_ITERATOR_SYMBOL = '@@iterator';
 

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -144,11 +144,19 @@ export type Thenable<T> =
   | FulfilledThenable<T>
   | RejectedThenable<T>;
 
+// A recoverable lets an intermediate renderer defer a subtree to a downstream
+// renderer. It does not produce a value: a renderer either continues through
+// it or interrupts the current render so that a later renderer can recover the
+// subtree.
+export type ReactRecoverable = Error & {
+  $$typeof: symbol,
+};
+
 export type StartTransitionOptions = {
   name?: string,
 };
 
-export type Usable<T> = Thenable<T> | ReactContext<T>;
+export type Usable<T> = Thenable<T> | ReactContext<T> | ReactRecoverable;
 
 export type ReactCustomFormAction = {
   name?: string,

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -42,6 +42,7 @@ export const enableAsyncDebugInfo: boolean = true;
 export const enableAsyncIterableChildren: boolean = false;
 export const enableCPUSuspense: boolean = true;
 export const enableCreateEventHandleAPI: boolean = false;
+export const enableBrowserAPI: boolean = true;
 export const enableEffectEventMutationPhase: boolean = true;
 export const enableMoveBefore: boolean = true;
 export const enableFizzExternalRuntime: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -28,6 +28,7 @@ export const enableAsyncDebugInfo: boolean = true;
 export const enableAsyncIterableChildren: boolean = false;
 export const enableCPUSuspense: boolean = false;
 export const enableCreateEventHandleAPI: boolean = false;
+export const enableBrowserAPI: boolean = true;
 export const enableMoveBefore: boolean = true;
 export const enableFizzExternalRuntime: boolean = true;
 export const enableInfiniteRenderLoopDetection: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -25,6 +25,7 @@ export const disableCommentsAsDOMContainers: boolean = true;
 export const disableInputAttributeSyncing: boolean = false;
 export const enableScopeAPI: boolean = false;
 export const enableCreateEventHandleAPI: boolean = false;
+export const enableBrowserAPI: boolean = true;
 export const enableSuspenseCallback: boolean = false;
 export const enableTrustedTypesIntegration: boolean = true;
 export const disableTextareaChildren: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -23,6 +23,7 @@ export const enableAsyncDebugInfo = true;
 export const enableAsyncIterableChildren = false;
 export const enableCPUSuspense = true;
 export const enableCreateEventHandleAPI = false;
+export const enableBrowserAPI = true;
 export const enableMoveBefore = false;
 export const enableFizzExternalRuntime = true;
 export const enableInfiniteRenderLoopDetection = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -25,6 +25,7 @@ export const disableCommentsAsDOMContainers: boolean = true;
 export const disableInputAttributeSyncing: boolean = false;
 export const enableScopeAPI: boolean = true;
 export const enableCreateEventHandleAPI: boolean = false;
+export const enableBrowserAPI: boolean = true;
 export const enableSuspenseCallback: boolean = true;
 export const disableLegacyContext: boolean = false;
 export const disableLegacyContextForFunctionComponents: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -80,6 +80,8 @@ export const disableCommentsAsDOMContainers: boolean = false;
 
 export const enableCreateEventHandleAPI: boolean = true;
 
+export const enableBrowserAPI: boolean = true;
+
 export const enableEffectEventMutationPhase: boolean = true;
 
 export const enableScopeAPI: boolean = true;

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -587,5 +587,9 @@
   "599": "Expected an initialized chunk but got an initialized stream chunk instead. This payload may have been submitted by an older version of React.",
   "600": "A rejected Promise was passed to React without a `reason` property. React threw a generic error from where the Promise was used to assist in identifying the problematic Promise. Make sure that instrumented Promises correctly set the `reason` property when setting `status` to `'rejected'`.",
   "601": "A chunk pair is incomplete. This is a bug in React.",
-  "602": "Cannot handle action key. This is a bug in React."
+  "602": "Cannot handle action key. This is a bug in React.",
+  "603": "Recoverable Exception: This is not a real error! It's an implementation detail of `use(browser())` to defer rendering to the browser. `use(browser())` can only be used inside a `<Suspense>` boundary. If a server render errors with this as its cause, the component that called `use(browser())` does not have a `<Suspense>` boundary above it.",
+  "604": "The server render could not complete because client rendering was requested outside a Suspense boundary. See this error's cause for additional details.",
+  "605": "Recoverable Exception: This is not a real error! It's an implementation detail of `use` to interrupt the current render so a downstream renderer can recover it. You must either rethrow it immediately, or move the `use` call outside of the `try/catch` block. Capturing without rethrowing will lead to unexpected behavior.",
+  "606": "Expected a suspended recoverable. This is a bug in React. Please file an issue."
 }


### PR DESCRIPTION
## Summary

Adds a new API to `react-dom` called `browser()`.

`browser()` returns a "usable" that will error during SSR and resolve during rendering in the browser. The purpose is to allow you to express the idea that a component should suspend on the server but not in the browser. The method is not available inside a `react-server` environment. This is a client only feature.

This is a `react-dom` API because the concept of browser doesn't apply generally to React itself.

This codifies a pattern that is common in some apps where you error during SSR to prevent rendering some component on the server and you end up suppressing the error that is reported in the client to avoid this appearing like a problem rather than intended behavior. Unfortunately this is not an option for many because hacking around to prevent errors from being logged is not practical for many

By making this a React API we enabled this common pattern in any React using library or application

```tsx
import {use, Suspense} from 'react';
import {browser} from 'react-dom';

function BrowserOnly() {
  use(browser());
  return <ClientContent />;
}

function App() {
  return (
    <Suspense fallback={<Fallback />}>
      <BrowserOnly />
    </Suspense>
  );
}
```

It is an error to `use(browser())` outside of a Suspense boundary because you cannot recover from the root. this restriction may be lifted in the future but is part of the current limitations of the API

## Implementation

Deferring rendering to a downstream system is modeled in React already as recoverable errors. The idea is that in some environments you might not want to report something directly as an error because a later environment has an opportunity to recover from it without alerting the user to the mishap. This concept also shows up in RSC with halted references. They can "recover" in a later render by eventually resolving to some value.

To model the idea of "render in the browser" we are really just modeling an intentional recoverable error. However since you don't want to treat this kind of error as exceptional we intentionally suppress logging. Additionally since aborting a server render is semantically equivalent to "erroring" in every unfinished task we also support aborting with a `browser()` so you can describe ending a stream with intentional holes that won't be logged as errors in the browser when hydrating.

One interesting thing we do with this particular API is it returns an object that is isomorphic and it's the `use` or `abort` function that handles differing behaviors. This means you can create these objects in module scope and use them even in complex scenarios like server rendering inside the browser while React is rendering.

This implementation is flagged so we can disable the feature quickly if we decide to not ship this in a stable. It is going into React unprefixed for now because the semantics are clear and the utility is widely known.

## Alternatives

We considered `useBrowser()` or a similar hook however this means you must call it unconditionally. There are use cases where props might influence whether you want to allow something to render during SSR or not. for instance you might have a data fetching library that accepts initial data on the server but if it doesn't receive initial data it falls back to browser only rendering.

Another consideration is a throwing function like just calling `browser()` would throw if called during an SSR render. The main reason we do not think this is a good idea is because you can then call this arbitrarily deep and the throw can be caught and might be suppressed accidentally. By making it a usable it can only be done in hooks or hook-like contexts.