### PR TITLE
[Flight] Add 'pending_weak' to Flight thenable protocol

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -46,6 +46,7 @@ import {
   enableProfilerTimer,
   enableComponentPerformanceTrack,
   enableAsyncDebugInfo,
+  enableFlightWeakThenables,
 } from 'shared/ReactFeatureFlags';
 
 import {
@@ -148,17 +149,35 @@ const ROW_CHUNK_BY_LENGTH = 4;
 type RowParserState = 0 | 1 | 2 | 3 | 4;
 
 const PENDING = 'pending';
+// A weak Promise reference. Behaves like PENDING except that when the stream
+// closes it transitions to HALTED instead of erroring, because the server
+// may intentionally never emit it. Only used when enableFlightWeakThenables
+// is on.
+const PENDING_WEAK = 'pending_weak';
 const BLOCKED = 'blocked';
 const RESOLVED_MODEL = 'resolved_model';
 const RESOLVED_MODULE = 'resolved_module';
 const INITIALIZED = 'fulfilled';
 const ERRORED = 'rejected';
-const HALTED = 'halted'; // DEV-only. Means it never resolves even if connection closes.
+// Means it never resolves, even when the connection closes. The shared
+// terminal state of a weak chunk that didn't settle before close, of any
+// pending chunk at close when partial streams are allowed, and of DEV-only
+// debug halts.
+const HALTED = 'halted';
 
 const __PROTO__ = '__proto__';
 
 type PendingChunk<T> = {
   status: 'pending',
+  value: null | Array<InitializationReference | (T => mixed)>,
+  reason: null | Array<InitializationReference | (mixed => mixed)>,
+  _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
+  _debugChunk: null | SomeChunk<ReactDebugInfoEntry>, // DEV-only
+  _debugInfo: ReactDebugInfo, // DEV-only
+  then(resolve: (T) => mixed, reject?: (mixed) => mixed): void,
+};
+type PendingWeakChunk<T> = {
+  status: 'pending_weak',
   value: null | Array<InitializationReference | (T => mixed)>,
   reason: null | Array<InitializationReference | (mixed => mixed)>,
   _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
@@ -233,6 +252,7 @@ type HaltedChunk<T> = {
 };
 type SomeChunk<T> =
   | PendingChunk<T>
+  | PendingWeakChunk<T>
   | BlockedChunk<T>
   | ResolvedModelChunk<T>
   | ResolvedModuleChunk<T>
@@ -301,6 +321,7 @@ function reactPromiseThen<T>(
       }
       break;
     case PENDING:
+    case PENDING_WEAK:
     case BLOCKED:
       if (typeof resolve === 'function') {
         if (chunk.value === null) {
@@ -444,6 +465,7 @@ function readChunk<T>(chunk: SomeChunk<T>): T {
     case INITIALIZED:
       return chunk.value;
     case PENDING:
+    case PENDING_WEAK:
     case BLOCKED:
     case HALTED:
       // eslint-disable-next-line no-throw-literal
@@ -474,6 +496,13 @@ function createPendingChunk<T>(response: Response): PendingChunk<T> {
   return new ReactPromise(PENDING, null, null);
 }
 
+function createPendingWeakChunk<T>(response: Response): PendingWeakChunk<T> {
+  // Unlike a regular pending chunk, a weak chunk may never settle, so it
+  // doesn't retain a strong reference to the Response while it waits.
+  // $FlowFixMe[invalid-constructor] Flow doesn't support functions as constructors
+  return new ReactPromise(PENDING_WEAK, null, null);
+}
+
 function releasePendingChunk(response: Response, chunk: SomeChunk<any>): void {
   if (__DEV__ && chunk.status === PENDING) {
     if (--response._pendingChunks === 0) {
@@ -490,6 +519,22 @@ function releasePendingChunk(response: Response, chunk: SomeChunk<any>): void {
       );
     }
   }
+}
+
+function createHaltedChunk<T>(response: Response): HaltedChunk<T> {
+  // $FlowFixMe[invalid-constructor] Flow doesn't support functions as constructors
+  return new ReactPromise(HALTED, null, null);
+}
+
+// Transition a chunk to HALTED: it will never resolve, even when the
+// connection closes. Clears any listeners to release their closures. Future
+// .then() calls on HALTED chunks are no-ops.
+function haltChunk<T>(response: Response, chunk: SomeChunk<T>): void {
+  releasePendingChunk(response, chunk);
+  const haltedChunk: HaltedChunk<T> = chunk as any;
+  haltedChunk.status = HALTED;
+  haltedChunk.value = null;
+  haltedChunk.reason = null;
 }
 
 function createBlockedChunk<T>(response: Response): BlockedChunk<T> {
@@ -750,7 +795,11 @@ function triggerErrorOnChunk<T>(
   chunk: SomeChunk<T>,
   error: mixed,
 ): void {
-  if (chunk.status !== PENDING && chunk.status !== BLOCKED) {
+  if (
+    chunk.status !== PENDING &&
+    chunk.status !== PENDING_WEAK &&
+    chunk.status !== BLOCKED
+  ) {
     // If we get more data to an already resolved ID, we assume that it's
     // a stream chunk since any other row shouldn't have more than one entry.
     const streamChunk: InitializedStreamChunk<any> = chunk as any;
@@ -762,7 +811,7 @@ function triggerErrorOnChunk<T>(
   releasePendingChunk(response, chunk);
   const listeners = chunk.reason;
 
-  if (__DEV__ && chunk.status === PENDING) {
+  if (__DEV__ && (chunk.status === PENDING || chunk.status === PENDING_WEAK)) {
     // Lazily initialize any debug info and block the initializing chunk on any unresolved entries.
     if (chunk._debugChunk != null) {
       const prevHandler = initializingHandler;
@@ -893,7 +942,7 @@ function resolveModelChunk<T>(
   chunk: SomeChunk<T>,
   value: UninitializedModel,
 ): void {
-  if (chunk.status !== PENDING) {
+  if (chunk.status !== PENDING && chunk.status !== PENDING_WEAK) {
     // If we get more data to an already resolved ID, we assume that it's
     // a stream chunk since any other row shouldn't have more than one entry.
     const streamChunk: InitializedStreamChunk<any> = chunk as any;
@@ -923,7 +972,11 @@ function resolveModuleChunk<T>(
   chunk: SomeChunk<T>,
   value: ClientReference<T>,
 ): void {
-  if (chunk.status !== PENDING && chunk.status !== BLOCKED) {
+  if (
+    chunk.status !== PENDING &&
+    chunk.status !== PENDING_WEAK &&
+    chunk.status !== BLOCKED
+  ) {
     // We already resolved. We didn't expect to see this.
     return;
   }
@@ -975,7 +1028,7 @@ let isInitializingDebugInfo: boolean = false;
 
 function initializeDebugChunk(
   response: Response,
-  chunk: ResolvedModelChunk<any> | PendingChunk<any>,
+  chunk: ResolvedModelChunk<any> | PendingChunk<any> | PendingWeakChunk<any>,
 ): void {
   const debugChunk = chunk._debugChunk;
   if (debugChunk !== null) {
@@ -1005,7 +1058,8 @@ function initializeDebugChunk(
             break;
           }
           case BLOCKED:
-          case PENDING: {
+          case PENDING:
+          case PENDING_WEAK: {
             waitForReference(
               initializedChunk,
               debugInfo,
@@ -1027,7 +1081,8 @@ function initializeDebugChunk(
             break;
           }
           case BLOCKED:
-          case PENDING: {
+          case PENDING:
+          case PENDING_WEAK: {
             // Signal to the caller that we need to wait.
             waitForReference(
               debugChunk,
@@ -1163,6 +1218,10 @@ export function reportGlobalError(
     // because we won't be getting any new data to resolve it.
     if (chunk.status === PENDING) {
       triggerErrorOnChunk(response, chunk, error);
+    } else if (enableFlightWeakThenables && chunk.status === PENDING_WEAK) {
+      // A weak Promise reference may never be emitted by the server. It
+      // stays forever pending instead of erroring.
+      haltChunk(response, chunk);
     } else if (chunk.status === INITIALIZED && chunk.reason !== null) {
       chunk.reason.error(error);
     }
@@ -1497,11 +1556,7 @@ function getChunk(response: Response, id: number): SomeChunk<any> {
       if (response._allowPartialStream) {
         // For partial streams, chunks accessed after close should be HALTED
         // (never resolve).
-        chunk = createPendingChunk(response);
-        const haltedChunk: HaltedChunk<any> = chunk as any;
-        haltedChunk.status = HALTED;
-        haltedChunk.value = null;
-        haltedChunk.reason = null;
+        chunk = createHaltedChunk(response);
       } else {
         // We have already errored the response and we're not going to get
         // anything more streaming in so this will immediately error.
@@ -1509,6 +1564,25 @@ function getChunk(response: Response, id: number): SomeChunk<any> {
       }
     } else {
       chunk = createPendingChunk(response);
+    }
+    chunks.set(id, chunk);
+  }
+  return chunk;
+}
+
+// Like getChunk, but for weak Promise references. The server may never emit
+// the row for a weak reference, so an unresolved weak chunk halts (stays
+// forever pending) instead of erroring when the stream closes.
+function getWeakChunk(response: Response, id: number): SomeChunk<any> {
+  const chunks = response._chunks;
+  let chunk = chunks.get(id);
+  if (!chunk) {
+    if (response._closed) {
+      // The stream already closed without emitting this row, so it will
+      // never resolve.
+      chunk = createHaltedChunk(response);
+    } else {
+      chunk = createPendingWeakChunk(response);
     }
     chunks.set(id, chunk);
   }
@@ -1569,7 +1643,8 @@ function fulfillReference(
               }
               // Fallthrough
             }
-            case PENDING: {
+            case PENDING:
+            case PENDING_WEAK: {
               // If we're not yet initialized we need to skip what we've already drilled
               // through and then wait for the next value to become available.
               path.splice(0, i - 1);
@@ -1773,7 +1848,7 @@ function rejectReference(
 }
 
 function waitForReference<T>(
-  referencedChunk: PendingChunk<T> | BlockedChunk<T>,
+  referencedChunk: PendingChunk<T> | PendingWeakChunk<T> | BlockedChunk<T>,
   parentObject: Object,
   key: string,
   response: Response,
@@ -2119,7 +2194,8 @@ function getOutlinedModel<T>(
               break;
             }
             case BLOCKED:
-            case PENDING: {
+            case PENDING:
+            case PENDING_WEAK: {
               return waitForReference(
                 referencedChunk,
                 parentObject,
@@ -2217,6 +2293,7 @@ function getOutlinedModel<T>(
       }
       return chunkValue;
     case PENDING:
+    case PENDING_WEAK:
     case BLOCKED:
       return waitForReference(
         chunk,
@@ -2452,6 +2529,23 @@ function parseModelString(
           }
         }
         return chunk;
+      }
+      case 'w': {
+        if (enableFlightWeakThenables) {
+          // Weak Promise
+          const id = parseInt(value.slice(2), 16);
+          const chunk = getWeakChunk(response, id);
+          if (enableProfilerTimer && enableComponentPerformanceTrack) {
+            if (
+              initializingChunk !== null &&
+              isArray(initializingChunk._children)
+            ) {
+              initializingChunk._children.push(chunk);
+            }
+          }
+          return chunk;
+        }
+        return undefined;
       }
       case 'S': {
         // Symbol
@@ -3019,14 +3113,14 @@ function resolveDebugHalt(response: Response, id: number): void {
     chunks.set(id, (chunk = createPendingChunk(response)));
   } else {
   }
-  if (chunk.status !== PENDING && chunk.status !== BLOCKED) {
+  if (
+    chunk.status !== PENDING &&
+    chunk.status !== PENDING_WEAK &&
+    chunk.status !== BLOCKED
+  ) {
     return;
   }
-  releasePendingChunk(response, chunk);
-  const haltedChunk: HaltedChunk<any> = chunk as any;
-  haltedChunk.status = HALTED;
-  haltedChunk.value = null;
-  haltedChunk.reason = null;
+  haltChunk(response, chunk);
 }
 
 function resolveModel(
@@ -5410,14 +5504,11 @@ export function close(weakResponse: WeakResponse): void {
     // For partial streams, we halt pending chunks instead of erroring them.
     response._closed = true;
     response._chunks.forEach(chunk => {
-      if (chunk.status === PENDING) {
-        // Clear listeners to release closures and transition to HALTED.
-        // Future .then() calls on HALTED chunks are no-ops.
-        releasePendingChunk(response, chunk);
-        const haltedChunk: HaltedChunk<any> = chunk as any;
-        haltedChunk.status = HALTED;
-        haltedChunk.value = null;
-        haltedChunk.reason = null;
+      if (
+        chunk.status === PENDING ||
+        (enableFlightWeakThenables && chunk.status === PENDING_WEAK)
+      ) {
+        haltChunk(response, chunk);
       } else if (chunk.status === INITIALIZED && chunk.reason !== null) {
         // Stream chunk - close gracefully instead of erroring.
         chunk.reason.close('"$undefined"');

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -2424,4 +2424,354 @@ describe('ReactFlightDOMEdge', () => {
       ).toString(),
     ).toBe('function () { [omitted code] }');
   });
+
+  // A thenable with status 'pending_weak' doesn't keep the Flight stream
+  // open. If it settles before the stream closes for other reasons its value
+  // is emitted like a normal pending thenable; otherwise its reference is
+  // left unfulfilled and stays forever pending on the client.
+  //
+  // A framework-style tracker for whether a page accessed its search params
+  // during a render. The params object is instrumented so that the first
+  // access settles the usedSearchParams thenable. It settles synchronously
+  // at the access point, so an access is guaranteed to be encoded before
+  // the response closes.
+  function createSearchParams(values) {
+    const listeners = [];
+    const usedSearchParams = {
+      status: 'pending_weak',
+      value: undefined,
+      then(onFulfill) {
+        if (usedSearchParams.status === 'fulfilled') {
+          onFulfill(usedSearchParams.value);
+        } else {
+          listeners.push(onFulfill);
+        }
+      },
+    };
+    const searchParams = new Proxy(values, {
+      get(target, key) {
+        if (usedSearchParams.status === 'pending_weak') {
+          usedSearchParams.status = 'fulfilled';
+          usedSearchParams.value = true;
+          for (let i = 0; i < listeners.length; i++) {
+            listeners[i](true);
+          }
+          listeners.length = 0;
+        }
+        return target[key];
+      },
+    });
+    return {searchParams, usedSearchParams};
+  }
+
+  it('emits the value of a weak-pending thenable that settles during the render', async () => {
+    const {searchParams, usedSearchParams} = createSearchParams({q: 'react'});
+
+    function Page() {
+      return <div>{'Results for ' + searchParams.q}</div>;
+    }
+
+    let response;
+    await serverAct(() => {
+      const stream = ReactServerDOMServer.renderToReadableStream({
+        usedSearchParams,
+        root: <Page />,
+      });
+      // Start consuming immediately, like a server that pipes the response
+      // while it renders.
+      response = ReactServerDOMClient.createFromReadableStream(stream, {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      });
+    });
+
+    const result = await response;
+    expect(await result.usedSearchParams).toBe(true);
+
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(result.root),
+    );
+    expect(await readResult(ssrStream)).toBe('<div>Results for react</div>');
+  });
+
+  // @gate enableFlightWeakThenables
+  it('completes the response without waiting for a weak-pending thenable that never settles', async () => {
+    const {searchParams, usedSearchParams} = createSearchParams({q: 'react'});
+
+    function Page() {
+      return <div>Static content</div>;
+    }
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream({
+        usedSearchParams,
+        root: <Page />,
+      }),
+    );
+    const [stream1, stream2] = stream.tee();
+
+    let content = null;
+    const readPromise = readResult(stream1).then(c => (content = c));
+    await serverAct(async () => {});
+    // The response completed even though the weak thenable never settled.
+    expect(content).not.toBe(null);
+    await readPromise;
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+
+    // Accessing the params after the response already completed doesn't do
+    // anything.
+    expect(searchParams.q).toBe('react');
+
+    // The reference is left forever pending, without erroring.
+    const raced = await Promise.race([
+      result.usedSearchParams,
+      Promise.resolve('never accessed'),
+    ]);
+    expect(raced).toBe('never accessed');
+  });
+
+  it('emits the value of a weak-pending thenable that settles while the response is still streaming', async () => {
+    const {searchParams, usedSearchParams} = createSearchParams({q: 'react'});
+
+    let resolveData;
+    const data = new Promise(res => (resolveData = res));
+    async function Results() {
+      const filter = await data;
+      return <div>{'Results for ' + searchParams[filter]}</div>;
+    }
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream({
+        usedSearchParams,
+        root: <Results />,
+      }),
+    );
+    const [stream1, stream2] = stream.tee();
+
+    let content = null;
+    const readPromise = readResult(stream1).then(c => (content = c));
+
+    // The response stays open while the data is loading — because of the
+    // async component, not because of the unresolved weak thenable.
+    await serverAct(async () => {});
+    expect(content).toBe(null);
+
+    // The data resolves, the component accesses the search params, and the
+    // response completes.
+    await serverAct(() => resolveData('q'));
+    await serverAct(async () => {});
+    expect(content).not.toBe(null);
+    await readPromise;
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(await result.usedSearchParams).toBe(true);
+
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(result.root),
+    );
+    expect(await readResult(ssrStream)).toBe('<div>Results for react</div>');
+  });
+
+  // @gate !enableFlightWeakThenables
+  it('treats a weak-pending thenable like a normal pending thenable when the flag is off', async () => {
+    const {searchParams, usedSearchParams} = createSearchParams({q: 'react'});
+
+    function Page() {
+      return <div>Static content</div>;
+    }
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream({
+        usedSearchParams,
+        root: <Page />,
+      }),
+    );
+    const [stream1, stream2] = stream.tee();
+
+    let content = null;
+    const readPromise = readResult(stream1).then(c => (content = c));
+
+    // Without the flag, the unknown thenable status is treated as an
+    // ordinary pending thenable, which keeps the response open.
+    await serverAct(async () => {});
+    expect(content).toBe(null);
+
+    // Accessing the params settles the thenable and lets the response
+    // complete.
+    await serverAct(() => {
+      expect(searchParams.q).toBe('react');
+    });
+    await serverAct(async () => {});
+    expect(content).not.toBe(null);
+    await readPromise;
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(await result.usedSearchParams).toBe(true);
+  });
+
+  // @gate enableFlightWeakThenables
+  it('supports linked lists of weak-pending thenables', async () => {
+    // Weak thenables compose recursively: the value that a weak-pending
+    // thenable settles with can itself contain more weak-pending thenables.
+    // A linked list of them forms an async sequence that never blocks the
+    // response from completing. Modeled here as a framework tracking which
+    // params a page accessed during a dynamic render, encoded into the
+    // response itself as WeakThenable<{value: T, next: WeakThenable<...>}>.
+    function instrumentParams(params) {
+      function createWeakNode() {
+        const listeners = [];
+        const node = {
+          status: 'pending_weak',
+          value: undefined,
+          then(onFulfill) {
+            if (node.status === 'fulfilled') {
+              onFulfill(node.value);
+            } else {
+              listeners.push(onFulfill);
+            }
+          },
+        };
+        return {node, listeners};
+      }
+      let tail = createWeakNode();
+      const head = tail.node;
+      const accessed = new Set();
+      const instrumentedParams = new Proxy(params, {
+        get(target, name) {
+          if (
+            typeof name === 'string' &&
+            name in target &&
+            !accessed.has(name)
+          ) {
+            accessed.add(name);
+            const settledTail = tail;
+            tail = createWeakNode();
+            // Settle the tail of the list synchronously at the access point
+            // so it's guaranteed to be encoded before the response closes.
+            const result = {value: name, next: tail.node};
+            settledTail.node.status = 'fulfilled';
+            settledTail.node.value = result;
+            for (let i = 0; i < settledTail.listeners.length; i++) {
+              settledTail.listeners[i](result);
+            }
+            settledTail.listeners.length = 0;
+          }
+          return target[name];
+        },
+      });
+      return {params: instrumentedParams, accessedParams: head};
+    }
+
+    const {params, accessedParams} = instrumentParams({
+      a: 'value-of-a',
+      b: 'value-of-b',
+      c: 'value-of-c',
+    });
+
+    function Page() {
+      // The page reads param a during the render.
+      return 'Accessed: ' + params.a;
+    }
+
+    let resolveNormal;
+    const pending = new Promise(res => {
+      resolveNormal = res;
+    });
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream({
+        accessedParams,
+        page: <Page />,
+        pending,
+      }),
+    );
+    const [stream1, stream2] = stream.tee();
+
+    let content = null;
+    const readPromise = readResult(stream1).then(c => (content = c));
+
+    // While the normal pending promise holds the stream open, param c is
+    // accessed, settling the next node of the list.
+    await serverAct(() => {
+      expect(params.c).toBe('value-of-c');
+    });
+    await serverAct(async () => {});
+    expect(content).toBe(null);
+
+    // Param b is never accessed, so the tail of the list stays unsettled.
+    // It doesn't keep the response open: once the normal promise resolves,
+    // the response completes.
+    await serverAct(() => {
+      resolveNormal('done');
+    });
+    await serverAct(async () => {});
+    expect(content).not.toBe(null);
+    await readPromise;
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(result.page).toBe('Accessed: value-of-a');
+
+    // Wait until the full response has been processed.
+    await serverAct(async () => {});
+
+    // Read the accessed params off the list, synchronously. A node that
+    // was never settled by the server stays forever pending, without
+    // erroring, which marks the end of the accessed params.
+    function readNode(node) {
+      // Attach a no-op listener to force Flight to synchronously unwrap a
+      // node that was received but not yet initialized.
+      node.then(() => {});
+      if (node.status !== 'fulfilled') {
+        return null;
+      }
+      return node.value;
+    }
+
+    const accessed = [];
+    let node = result.accessedParams;
+    while (node !== null) {
+      const entry = readNode(node);
+      if (entry === null) {
+        break;
+      }
+      accessed.push(entry.value);
+      node = entry.next;
+    }
+    expect(accessed).toEqual(['a', 'c']);
+  });
 });

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -16,6 +16,7 @@ import {
   enableProfilerTimer,
   enableComponentPerformanceTrack,
   enableAsyncDebugInfo,
+  enableFlightWeakThenables,
 } from 'shared/ReactFeatureFlags';
 
 import {
@@ -1078,12 +1079,12 @@ function emitRequestedDebugThenable(
   );
 }
 
-function serializeThenable(
+function createThenableTask(
   request: Request,
   task: Task,
   thenable: Thenable<any>,
-): number {
-  const newTask = createTask(
+): Task {
+  return createTask(
     request,
     thenable as any, // will be replaced by the value before we retry. used for debug info.
     task.keyPath, // the server component sequence continues through Promise-as-a-child.
@@ -1098,9 +1099,16 @@ function serializeThenable(
     __DEV__ ? task.debugStack : null,
     __DEV__ ? task.debugTask : null,
   );
+}
 
+function serializeThenable(
+  request: Request,
+  task: Task,
+  thenable: Thenable<any>,
+): number {
   switch (thenable.status) {
     case 'fulfilled': {
+      const newTask = createThenableTask(request, task, thenable);
       forwardDebugInfoFromThenable(request, newTask, thenable, null, null);
       // We have the resolved value, we can go ahead and schedule it for serialization.
       newTask.model = thenable.value;
@@ -1108,12 +1116,102 @@ function serializeThenable(
       return newTask.id;
     }
     case 'rejected': {
+      const newTask = createThenableTask(request, task, thenable);
       forwardDebugInfoFromThenable(request, newTask, thenable, null, null);
       const x = thenable.reason;
       erroredTask(request, newTask, x);
       return newTask.id;
     }
+    case 'pending_weak': {
+      if (enableFlightWeakThenables) {
+        // A weak-pending thenable doesn't block the stream from closing, so
+        // we don't create a task for it yet. We only reserve an id for its
+        // reference. If it settles while the stream is still open, we
+        // create the task at that point, the same as if we had serialized
+        // an already settled thenable.
+        //
+        // Delivery is driven by the thenable's notification. If the stream
+        // closes before the listeners are notified, the value is dropped
+        // and the reference is left unfulfilled. Since the stream may close
+        // synchronously when the last task completes, a thenable that
+        // notifies its listeners synchronously (unlike a native Promise,
+        // which notifies in a microtask) is guaranteed delivery of any
+        // value it settles with before the stream closes.
+        const id = request.nextChunkId++;
+        // The parent task is mutated as serialization continues, so we
+        // snapshot the context that the new task needs if it's created
+        // later.
+        const keyPath = task.keyPath;
+        const implicitSlot = task.implicitSlot;
+        const formatContext = task.formatContext;
+        const lastTimestamp =
+          enableProfilerTimer &&
+          (enableComponentPerformanceTrack || enableAsyncDebugInfo)
+            ? task.time
+            : 0;
+        const debugOwner = __DEV__ ? task.debugOwner : null;
+        const debugStack = __DEV__ ? task.debugStack : null;
+        const debugTask = __DEV__ ? task.debugTask : null;
+        let settled = false;
+        thenable.then(
+          (value: any) => {
+            if (settled || request.status > OPEN) {
+              // Too late. The stream already closed (or the request was
+              // aborted), so the reference stays unfulfilled.
+              return;
+            }
+            settled = true;
+            const newTask = createTaskWithID(
+              request,
+              id,
+              value,
+              keyPath,
+              implicitSlot,
+              formatContext,
+              request.abortableTasks,
+              lastTimestamp,
+              debugOwner,
+              debugStack,
+              debugTask,
+            );
+            forwardDebugInfoFromCurrentContext(request, newTask, thenable);
+            pingTask(request, newTask);
+          },
+          (reason: mixed) => {
+            if (settled || request.status > OPEN) {
+              return;
+            }
+            settled = true;
+            const newTask = createTaskWithID(
+              request,
+              id,
+              thenable as any, // never rendered. used for debug info.
+              keyPath,
+              implicitSlot,
+              formatContext,
+              request.abortableTasks,
+              lastTimestamp,
+              debugOwner,
+              debugStack,
+              debugTask,
+            );
+            if (
+              enableProfilerTimer &&
+              (enableComponentPerformanceTrack || enableAsyncDebugInfo)
+            ) {
+              // If this is async we need to time when this task finishes.
+              newTask.timed = true;
+            }
+            erroredTask(request, newTask, reason);
+            enqueueFlush(request);
+          },
+        );
+        return id;
+      }
+      // Fallthrough
+    }
     default: {
+      const newTask = createThenableTask(request, task, thenable);
       if (request.status === ABORTING) {
         // We can no longer accept any resolved values
         request.abortableTasks.delete(newTask);
@@ -1127,59 +1225,56 @@ function serializeThenable(
         }
         return newTask.id;
       }
-      if (typeof thenable.status === 'string') {
+      if (typeof thenable.status !== 'string') {
         // Only instrument the thenable if the status if not defined. If
         // it's defined, but an unknown value, assume it's been instrumented by
         // some custom userspace implementation. We treat it as "pending".
-        break;
+        const pendingThenable: PendingThenable<mixed> = thenable as any;
+        pendingThenable.status = 'pending';
+        pendingThenable.then(
+          fulfilledValue => {
+            if (thenable.status === 'pending') {
+              const fulfilledThenable: FulfilledThenable<mixed> =
+                thenable as any;
+              fulfilledThenable.status = 'fulfilled';
+              fulfilledThenable.value = fulfilledValue;
+            }
+          },
+          (error: mixed) => {
+            if (thenable.status === 'pending') {
+              const rejectedThenable: RejectedThenable<mixed> = thenable as any;
+              rejectedThenable.status = 'rejected';
+              rejectedThenable.reason = error;
+            }
+          },
+        );
       }
-      const pendingThenable: PendingThenable<mixed> = thenable as any;
-      pendingThenable.status = 'pending';
-      pendingThenable.then(
-        fulfilledValue => {
-          if (thenable.status === 'pending') {
-            const fulfilledThenable: FulfilledThenable<mixed> = thenable as any;
-            fulfilledThenable.status = 'fulfilled';
-            fulfilledThenable.value = fulfilledValue;
-          }
+      thenable.then(
+        value => {
+          forwardDebugInfoFromCurrentContext(request, newTask, thenable);
+          newTask.model = value;
+          pingTask(request, newTask);
         },
-        (error: mixed) => {
-          if (thenable.status === 'pending') {
-            const rejectedThenable: RejectedThenable<mixed> = thenable as any;
-            rejectedThenable.status = 'rejected';
-            rejectedThenable.reason = error;
+        reason => {
+          if (newTask.status === PENDING) {
+            if (
+              enableProfilerTimer &&
+              (enableComponentPerformanceTrack || enableAsyncDebugInfo)
+            ) {
+              // If this is async we need to time when this task finishes.
+              newTask.timed = true;
+            }
+            // We expect that the only status it might be otherwise is ABORTED.
+            // When we abort we emit chunks in each pending task slot and don't need
+            // to do so again here.
+            erroredTask(request, newTask, reason);
+            enqueueFlush(request);
           }
         },
       );
-      break;
+      return newTask.id;
     }
   }
-
-  thenable.then(
-    value => {
-      forwardDebugInfoFromCurrentContext(request, newTask, thenable);
-      newTask.model = value;
-      pingTask(request, newTask);
-    },
-    reason => {
-      if (newTask.status === PENDING) {
-        if (
-          enableProfilerTimer &&
-          (enableComponentPerformanceTrack || enableAsyncDebugInfo)
-        ) {
-          // If this is async we need to time when this task finishes.
-          newTask.timed = true;
-        }
-        // We expect that the only status it might be otherwise is ABORTED.
-        // When we abort we emit chunks in each pending task slot and don't need
-        // to do so again here.
-        erroredTask(request, newTask, reason);
-        enqueueFlush(request);
-      }
-    },
-  );
-
-  return newTask.id;
 }
 
 function serializeReadableStream(
@@ -2761,8 +2856,35 @@ function createTask(
   debugStack: null | Error, // DEV-only
   debugTask: null | ConsoleTask, // DEV-only
 ): Task {
+  return createTaskWithID(
+    request,
+    request.nextChunkId++,
+    model,
+    keyPath,
+    implicitSlot,
+    formatContext,
+    abortSet,
+    lastTimestamp,
+    debugOwner,
+    debugStack,
+    debugTask,
+  );
+}
+
+function createTaskWithID(
+  request: Request,
+  id: number,
+  model: ReactClientValue,
+  keyPath: ReactKey,
+  implicitSlot: boolean,
+  formatContext: FormatContext,
+  abortSet: Set<Task>,
+  lastTimestamp: number, // Profiling-only
+  debugOwner: null | ReactComponentInfo, // DEV-only
+  debugStack: null | Error, // DEV-only
+  debugTask: null | ConsoleTask, // DEV-only
+): Task {
   request.pendingChunks++;
-  const id = request.nextChunkId++;
   if (typeof model === 'object' && model !== null) {
     // If we're about to write this into a new task we can assign it an ID early so that
     // any other references can refer to the value we're about to write.
@@ -2940,6 +3062,10 @@ function serializeLazyID(id: number): string {
 
 function serializePromiseID(id: number): string {
   return '$@' + id.toString(16);
+}
+
+function serializeWeakPromiseID(id: number): string {
+  return '$w' + id.toString(16);
 }
 
 function serializeServerReferenceID(id: number): string {
@@ -3828,13 +3954,20 @@ function renderModelDestructive(
     const existingReference = writtenObjects.get(value);
     // $FlowFixMe[method-unbinding]
     if (typeof value.then === 'function') {
+      // A weak-pending thenable may never emit, so its reference is marked
+      // on the wire ($w instead of $@). That way the client knows to leave
+      // it forever pending, instead of erroring it, if the stream closes
+      // first.
       if (existingReference !== undefined) {
         if (task.keyPath !== null || task.implicitSlot) {
           // If we're in some kind of context we can't reuse the result of this render or
           // previous renders of this element. We only reuse Promises if they're not wrapped
           // by another Server Component.
           const promiseId = serializeThenable(request, task, value as any);
-          return serializePromiseID(promiseId);
+          return enableFlightWeakThenables &&
+            (value as any).status === 'pending_weak'
+            ? serializeWeakPromiseID(promiseId)
+            : serializePromiseID(promiseId);
         } else if (modelRoot === value) {
           // This is the ID we're currently emitting so we need to write it
           // once but if we discover it again, we refer to it by id.
@@ -3847,7 +3980,10 @@ function renderModelDestructive(
       // We assume that any object with a .then property is a "Thenable" type,
       // or a Promise type. Either of which can be represented by a Promise.
       const promiseId = serializeThenable(request, task, value as any);
-      const promiseReference = serializePromiseID(promiseId);
+      const promiseReference =
+        enableFlightWeakThenables && (value as any).status === 'pending_weak'
+          ? serializeWeakPromiseID(promiseId)
+          : serializePromiseID(promiseId);
       writtenObjects.set(value, promiseReference);
       return promiseReference;
     }
@@ -6157,6 +6293,12 @@ function finishAbortedTask(
   request.completedErrorChunks.push(processedChunk);
 }
 
+// "Halting" a task means finishing it without emitting anything into its
+// slot: the reference is intentionally left unfulfilled and never resolves
+// on the client. This is how an aborted prerender leaves its pending work.
+// It's also the same outcome as a weak-pending thenable that never settles
+// (see serializeThenable) — halting is initiated by the request aborting,
+// weakness by the value itself.
 function haltTask(task: Task, request: Request): void {
   if (task.status !== PENDING) {
     // If this is already completed/errored we don't abort it.

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -76,6 +76,12 @@ export const enableLegacyCache = __EXPERIMENTAL__;
 
 export const enableAsyncIterableChildren = __EXPERIMENTAL__;
 
+// Support thenables with status 'pending_weak' in Flight. A weak-pending
+// thenable doesn't keep the stream open; if it resolves before the stream
+// closes for other reasons, its value is emitted, otherwise its reference is
+// left unfulfilled.
+export const enableFlightWeakThenables = __EXPERIMENTAL__;
+
 export const enableTaint = __EXPERIMENTAL__;
 
 export const enableViewTransition: boolean = true;

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -126,6 +126,11 @@ export interface PendingThenable<T> extends ThenableImpl<T> {
   _debugInfo?: null | ReactDebugInfo;
 }
 
+export interface WeakPendingThenable<T> extends ThenableImpl<T> {
+  status: 'pending_weak';
+  _debugInfo?: null | ReactDebugInfo;
+}
+
 export interface FulfilledThenable<T> extends ThenableImpl<T> {
   status: 'fulfilled';
   value: T;
@@ -141,6 +146,7 @@ export interface RejectedThenable<T> extends ThenableImpl<T> {
 export type Thenable<T> =
   | UntrackedThenable<T>
   | PendingThenable<T>
+  | WeakPendingThenable<T>
   | FulfilledThenable<T>
   | RejectedThenable<T>;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -40,6 +40,7 @@ export const disableSchedulerTimeoutInWorkLoop: boolean = false;
 export const disableTextareaChildren: boolean = false;
 export const enableAsyncDebugInfo: boolean = true;
 export const enableAsyncIterableChildren: boolean = false;
+export const enableFlightWeakThenables: boolean = false;
 export const enableCPUSuspense: boolean = true;
 export const enableCreateEventHandleAPI: boolean = false;
 export const enableEffectEventMutationPhase: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -26,6 +26,7 @@ export const disableSchedulerTimeoutInWorkLoop: boolean = false;
 export const disableTextareaChildren: boolean = false;
 export const enableAsyncDebugInfo: boolean = true;
 export const enableAsyncIterableChildren: boolean = false;
+export const enableFlightWeakThenables: boolean = false;
 export const enableCPUSuspense: boolean = false;
 export const enableCreateEventHandleAPI: boolean = false;
 export const enableMoveBefore: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -20,6 +20,7 @@ export const enablePerformanceIssueReporting: boolean = false;
 export const enableUpdaterTracking: boolean = false;
 export const enableLegacyCache: boolean = __EXPERIMENTAL__;
 export const enableAsyncIterableChildren: boolean = false;
+export const enableFlightWeakThenables: boolean = false;
 export const enableTaint: boolean = true;
 export const disableCommentsAsDOMContainers: boolean = true;
 export const disableInputAttributeSyncing: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -21,6 +21,7 @@ export const disableSchedulerTimeoutInWorkLoop = false;
 export const disableTextareaChildren = false;
 export const enableAsyncDebugInfo = true;
 export const enableAsyncIterableChildren = false;
+export const enableFlightWeakThenables = false;
 export const enableCPUSuspense = true;
 export const enableCreateEventHandleAPI = false;
 export const enableMoveBefore = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -20,6 +20,7 @@ export const enablePerformanceIssueReporting: boolean = false;
 export const enableUpdaterTracking: boolean = false;
 export const enableLegacyCache: boolean = true;
 export const enableAsyncIterableChildren: boolean = false;
+export const enableFlightWeakThenables: boolean = false;
 export const enableTaint: boolean = true;
 export const disableCommentsAsDOMContainers: boolean = true;
 export const disableInputAttributeSyncing: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -71,6 +71,7 @@ export const disableLegacyContext = __EXPERIMENTAL__;
 export const enableLegacyCache: boolean = true;
 
 export const enableAsyncIterableChildren: boolean = false;
+export const enableFlightWeakThenables: boolean = false;
 
 export const enableTaint: boolean = false;
 


### PR DESCRIPTION
Added behind a new experimental flag, `enableFlightWeakThenables`.

Adds a new thenable status to the Flight protocol: `'pending_weak'`. Unlike a regular pending thenable, a weak thenable does not block the stream from closing. If it settles while the stream is still open, its value is emitted like a normal pending thenable. Otherwise its reference is left unfulfilled and on the client it stays forever pending, without erroring, even when the connection closes. It's up to the client to handle the unresolved promise in an appropriate way.

The motivating use case is being able to encode metadata about a Flight stream into the response itself. For example, a framework might want to track whether a page varies by search params. It could represent this in the response as a `Promise<boolean>` that resolves to `true` as soon as the component being rendered in the stream accesses search params. If the thenable never resolves by the time the stream closes, then the client knows that no search params were ever accessed.

In the future we could add a higher-level API for encoding this kind of information. For now, we intentionally start with the low-level primitive so frameworks can experiment in userspace without adding significantly to React's surface area.

Internally, Flight already uses its own private thenable statuses, like `'resolved_model'`, and the protocol is designed to treat any status besides `'fulfilled'` and `'rejected'` as equivalent to `'pending'`, so `'pending_weak'` slots into the existing machinery. On the wire, a weak reference is encoded as `$w<id>`, next to `$@<id>` for regular promises, so the client knows its row may intentionally never arrive. On the client, a weak reference behaves like any other pending promise until the response closes; then, instead of erroring, it is left forever pending.
