### PR TITLE
[Fiber] Guard against null memoizedProps when diffing props in DEV perf track

### DIFF
--- a/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
+++ b/packages/react-reconciler/src/ReactFiberPerformanceTrack.js
@@ -269,6 +269,7 @@ export function logComponentRender(
       if (
         props !== null &&
         alternate !== null &&
+        alternate.memoizedProps !== null &&
         alternate.memoizedProps !== props
       ) {
         // If this is an update, we'll diff the props and emit which ones changed.


### PR DESCRIPTION
## Summary

In DEV, `logComponentRender` diffs previous vs. next props to populate the "Changed Props" entry on the Components performance track. The guard checks `props !== null` and `alternate !== null`, but not `alternate.memoizedProps !== null`:

```js
if (
  props !== null &&
  alternate !== null &&
  alternate.memoizedProps !== props
) {
  const isDeeplyEqual = addObjectDiffToProperties(
    alternate.memoizedProps, // can be null here
    props,
    ...
```

A fiber whose alternate never completed a render can reach this with `alternate.memoizedProps === null`, and `addObjectDiffToProperties(null, props, …)` then throws on `key in prev`:

```
TypeError: Cannot use 'in' operator to search for 'headCacheNode' in null
    at addObjectDiffToProperties
    at logComponentRender
    at commitPassiveMountOnFiber
```

(The key name is just whatever the first next-prop is — here `headCacheNode` from Next.js's internal `Head` component.)

Because the throw happens during the passive-effects commit, the work loop is left in an inconsistent state and the next synchronous render fails with `Error: Should not already be working.` at `performWorkOnRoot`, so a dev-only logging feature takes the whole app down.

This reproduces reliably in a Next.js 16 App Router app by clicking between routes fast enough that one navigation interrupts the previous one (a few clicks 25–150 ms apart). Related crashes in this same code path: #36430, #35126.

The fix skips the diff when there are no previous props to diff against, treating it like the mount case (plain `console.timeStamp` entry, no "Changed Props").

## How did you test this change?

- Reproduced the crash in a Next.js 16.2.12 app (vendored react-dom 19.2.8 development bundle): scripted rapid route changes produced both errors within ~10 navigations, every run.
- Applied this same one-line guard to the compiled `react-dom-client.development.js` in that app: 72 rapid navigations across 3 routes with 25–150 ms spacing produced zero errors (verified via `window.onerror`/`unhandledrejection` collectors and CDP page-error events), repeated across fresh sessions.
- The guard only narrows the existing condition, so mount and normal-update logging behavior is unchanged.