### PR TITLE
[DevTools] Redesign the Profiler empty states around a primary action

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/NoProfilingData.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/NoProfilingData.js
@@ -8,28 +8,34 @@
  */
 
 import * as React from 'react';
-import RecordToggle from './RecordToggle';
+import {useContext} from 'react';
+import {ProfilerContext} from './ProfilerContext';
 
 import styles from './Profiler.css';
 
 export default function NoProfilingData(): React.Node {
+  const {startProfiling} = useContext(ProfilerContext);
+
   return (
     <div className={styles.Column}>
-      <div className={styles.Header}>No profiling data has been recorded.</div>
-      <div className={styles.Row}>
-        Click the record button <RecordToggle /> to start recording.
-      </div>
-      <div className={`${styles.Row} ${styles.LearnMoreRow}`}>
-        Click{' '}
+      <div className={styles.Header}>No profiling data has been recorded</div>
+      <div className={styles.Description}>
+        Record a session to see which components rendered, how long they took,
+        and why.{' '}
         <a
-          className={styles.LearnMoreLink}
-          href="https://fb.me/react-devtools-profiling"
+          className={styles.DescriptionLink}
+          href="https://legacy.reactjs.org/blog/2018/09/10/introducing-the-react-profiler.html"
           rel="noopener noreferrer"
           target="_blank">
-          here
-        </a>{' '}
-        to learn more about profiling.
+          Learn more
+        </a>
       </div>
+      <button
+        className={styles.CTAButton}
+        onClick={startProfiling}
+        type="button">
+        Start recording
+      </button>
     </div>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.css
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.css
@@ -61,15 +61,44 @@
   justify-content: center;
 }
 
-.LearnMoreRow {
-  margin-top: 1rem;
-  color: var(--color-dim);
-  font-size: var(--font-size-sans-small);
-}
-
 .Header {
   font-size: var(--font-size-sans-large);
-  margin-bottom: 0.5rem;
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+.Description {
+  max-width: 26rem;
+  text-align: center;
+  color: var(--color-dim);
+}
+
+.DescriptionLink {
+  color: var(--color-link);
+  text-decoration: underline;
+}
+
+.CTAButton {
+  margin-top: 0.5rem;
+  padding: 0.375rem 1rem;
+  border: none;
+  border-radius: 1rem;
+  background: var(--color-background-hover);
+  color: var(--color-button-focus);
+  font-family: inherit;
+  font-size: var(--font-size-sans-normal);
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.CTAButton:hover {
+  background: var(--color-background-selected);
+  color: var(--color-text-selected);
+}
+
+.CTAButton:focus-visible {
+  outline: 2px solid var(--color-button-active);
+  outline-offset: 2px;
 }
 
 .Toolbar {
@@ -126,10 +155,4 @@
   flex: 1 1;
   display: flex;
   align-items: center;
-}
-
-.LearnMoreLink {
-  color: var(--color-link);
-  margin-left: 0.25rem;
-  margin-right: 0.25rem;
 }

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/RecordingInProgress.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/RecordingInProgress.js
@@ -8,17 +8,23 @@
  */
 
 import * as React from 'react';
-import RecordToggle from './RecordToggle';
+import {useContext} from 'react';
+import {ProfilerContext} from './ProfilerContext';
 
 import styles from './Profiler.css';
 
 export default function RecordingInProgress(): React.Node {
+  const {stopProfiling} = useContext(ProfilerContext);
+
   return (
     <div className={styles.Column}>
       <div className={styles.Header}>Profiling is in progress...</div>
-      <div className={styles.Row}>
-        Click the record button <RecordToggle /> to stop recording.
-      </div>
+      <button
+        className={styles.CTAButton}
+        onClick={stopProfiling}
+        type="button">
+        Stop recording
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="752" height="835" alt="before" src="https://github.com/user-attachments/assets/225d131c-a09c-44dd-ae79-0d76a8874d70" /> | <img width="751" height="832" alt="after" src="https://github.com/user-attachments/assets/8547a921-adc4-4abb-a40f-5ae74c1287b2" /> | 
