### PR TITLE
[DevTools] Remove Timeline profiler tab, suggest React Performance tracks

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Icon.js
+++ b/packages/react-devtools-shared/src/devtools/views/Icon.js
@@ -21,7 +21,6 @@ export type IconType =
   | 'flame-chart'
   | 'profiler'
   | 'ranked-chart'
-  | 'timeline'
   | 'search'
   | 'settings'
   | 'store-as-global-variable'
@@ -74,9 +73,6 @@ export default function Icon({
       break;
     case 'ranked-chart':
       pathData = PATH_RANKED_CHART;
-      break;
-    case 'timeline':
-      pathData = PATH_SCHEDULING_PROFILER;
       break;
     case 'search':
       pathData = PATH_SEARCH;
@@ -158,11 +154,6 @@ const PATH_FLAME_CHART = `
 `;
 
 const PATH_PROFILER = 'M5 9.2h3V19H5zM10.6 5h2.8v14h-2.8zm5.6 8H19v6h-2.8z';
-
-const PATH_SCHEDULING_PROFILER = `
-  M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0
-  16H5V9h14v10zm0-12H5V5h14v2zM7 11h5v5H7z
-`;
 
 const PATH_SEARCH = `
   M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ClearProfilingDataButton.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ClearProfilingDataButton.js
@@ -13,31 +13,23 @@ import {ProfilerContext} from './ProfilerContext';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import {StoreContext} from '../context';
-import {TimelineContext} from 'react-devtools-timeline/src/TimelineContext';
 
 export default function ClearProfilingDataButton(): React.Node {
   const store = useContext(StoreContext);
   const {didRecordCommits, isProfiling} = useContext(ProfilerContext);
-  const {file, setFile} = useContext(TimelineContext);
   const {profilerStore} = store;
 
   const doesHaveInMemoryData = didRecordCommits;
-  const doesHaveUserTimingData = file !== null;
 
   const clear = () => {
     if (doesHaveInMemoryData) {
       profilerStore.clear();
     }
-    if (doesHaveUserTimingData) {
-      setFile(null);
-    }
   };
 
   return (
     <Button
-      disabled={
-        isProfiling || !(doesHaveInMemoryData || doesHaveUserTimingData)
-      }
+      disabled={isProfiling || !doesHaveInMemoryData}
       onClick={clear}
       title="Clear profiling data">
       <ButtonIcon type="clear" />

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/NoProfilingData.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/NoProfilingData.js
@@ -8,13 +8,38 @@
  */
 
 import * as React from 'react';
-import {useContext} from 'react';
+import {useContext, useSyncExternalStore} from 'react';
 import {ProfilerContext} from './ProfilerContext';
+import {StoreContext} from '../context';
 
 import styles from './Profiler.css';
 
 export default function NoProfilingData(): React.Node {
   const {startProfiling} = useContext(ProfilerContext);
+  const store = useContext(StoreContext);
+
+  // React only started emitting Performance tracks in 19.2.
+  const supportsPerformanceTracks = useSyncExternalStore<boolean>(
+    function subscribe(callback) {
+      store.addListener('rootSupportsPerformanceTracks', callback);
+      return function unsubscribe() {
+        store.removeListener('rootSupportsPerformanceTracks', callback);
+      };
+    },
+    function getState() {
+      return store.rootSupportsPerformanceTracks;
+    },
+  );
+
+  const performanceTracksLink = (
+    <a
+      className={styles.DescriptionLink}
+      href="https://react.dev/reference/dev-tools/react-performance-tracks"
+      rel="noopener noreferrer"
+      target="_blank">
+      Performance tracks
+    </a>
+  );
 
   return (
     <div className={styles.Column}>
@@ -36,6 +61,20 @@ export default function NoProfilingData(): React.Node {
         type="button">
         Start recording
       </button>
+      <div className={styles.PerformanceTracksCard}>
+        To profile scheduling and rendering on a timeline,{' '}
+        {supportsPerformanceTracks ? (
+          <>
+            record a profile in the Performance panel — React adds its own{' '}
+            {performanceTracksLink} there.
+          </>
+        ) : (
+          <>
+            upgrade to React 19.2 or newer, which adds {performanceTracksLink}{' '}
+            to the Performance panel.
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.css
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.css
@@ -68,7 +68,7 @@
 }
 
 .Description {
-  max-width: 26rem;
+  max-width: 100%;
   text-align: center;
   color: var(--color-dim);
 }
@@ -76,6 +76,16 @@
 .DescriptionLink {
   color: var(--color-link);
   text-decoration: underline;
+}
+
+.PerformanceTracksCard {
+  margin-top: 1.5rem;
+  max-width: 80%;
+  padding: 0.625rem 0.75rem;
+  background: var(--color-background-hover);
+  /* Squarer than the CTA's pill, so the two don't read as the same control. */
+  border-radius: 0.25rem;
+  text-align: center;
 }
 
 .CTAButton {
@@ -149,10 +159,4 @@
 
 .Link {
   color: var(--color-button);
-}
-
-.TimelineSearchInputContainer {
-  flex: 1 1;
-  display: flex;
-  align-items: center;
 }

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
@@ -16,8 +16,6 @@ import ClearProfilingDataButton from './ClearProfilingDataButton';
 import CommitFlamegraph from './CommitFlamegraph';
 import CommitRanked from './CommitRanked';
 import RootSelector from './RootSelector';
-import {Timeline} from 'react-devtools-timeline/src/Timeline';
-import SidebarEventInfo from './SidebarEventInfo';
 import RecordToggle from './RecordToggle';
 import ReloadAndProfileButton from './ReloadAndProfileButton';
 import ProfilingImportExportButtons from './ProfilingImportExportButtons';
@@ -32,8 +30,6 @@ import SettingsModal from 'react-devtools-shared/src/devtools/views/Settings/Set
 import SettingsModalContextToggle from 'react-devtools-shared/src/devtools/views/Settings/SettingsModalContextToggle';
 import {SettingsModalContextController} from 'react-devtools-shared/src/devtools/views/Settings/SettingsModalContext';
 import portaledContent from '../portaledContent';
-import {StoreContext} from '../context';
-import {TimelineContext} from 'react-devtools-timeline/src/TimelineContext';
 
 import styles from './Profiler.css';
 
@@ -58,13 +54,6 @@ function Profiler(_: {}) {
     selectNextCommitIndex,
   } = useContext(ProfilerContext);
 
-  const {file: timelineTraceEventData, searchInputContainerRef} =
-    useContext(TimelineContext);
-
-  const {supportsTimeline} = useContext(StoreContext);
-
-  const isLegacyProfilerSelected = selectedTabID !== 'timeline';
-
   const handleKeyDown = useEffectEvent((event: KeyboardEvent) => {
     const correctModifier = isMac ? event.metaKey : event.ctrlKey;
     // Cmd+E to start/stop profiler recording
@@ -76,11 +65,7 @@ function Profiler(_: {}) {
       }
       event.preventDefault();
       event.stopPropagation();
-    } else if (
-      isLegacyProfilerSelected &&
-      didRecordCommits &&
-      selectedCommitIndex !== null
-    ) {
+    } else if (didRecordCommits && selectedCommitIndex !== null) {
       // Cmd+Left/Right (Mac) or Ctrl+Left/Right (Windows/Linux) to navigate commits
       if (
         correctModifier &&
@@ -110,16 +95,13 @@ function Profiler(_: {}) {
   }, []);
 
   let view = null;
-  if (didRecordCommits || selectedTabID === 'timeline') {
+  if (didRecordCommits) {
     switch (selectedTabID) {
       case 'flame-chart':
         view = <CommitFlamegraph />;
         break;
       case 'ranked-chart':
         view = <CommitRanked />;
-        break;
-      case 'timeline':
-        view = <Timeline />;
         break;
       default:
         break;
@@ -128,8 +110,6 @@ function Profiler(_: {}) {
     view = <RecordingInProgress />;
   } else if (isProcessingData) {
     view = <ProcessingData />;
-  } else if (timelineTraceEventData) {
-    view = <OnlyTimelineData />;
   } else if (supportsProfiling) {
     view = <NoProfilingData />;
   } else {
@@ -155,9 +135,6 @@ function Profiler(_: {}) {
           }
         }
         break;
-      case 'timeline':
-        sidebar = <SidebarEventInfo />;
-        break;
       default:
         break;
     }
@@ -177,19 +154,13 @@ function Profiler(_: {}) {
               currentTab={selectedTabID}
               id="Profiler"
               selectTab={selectTab}
-              tabs={supportsTimeline ? tabsWithTimeline : tabs}
+              tabs={tabs}
               type="profiler"
             />
             <RootSelector />
             <div className={styles.Spacer} />
-            {!isLegacyProfilerSelected && (
-              <div
-                ref={searchInputContainerRef}
-                className={styles.TimelineSearchInputContainer}
-              />
-            )}
             <SettingsModalContextToggle />
-            {isLegacyProfilerSelected && didRecordCommits && (
+            {didRecordCommits && (
               <Fragment>
                 <div className={styles.VRule} />
                 <SnapshotSelector />
@@ -208,15 +179,6 @@ function Profiler(_: {}) {
   );
 }
 
-const OnlyTimelineData = () => (
-  <div className={styles.Column}>
-    <div className={styles.Header}>Timeline only</div>
-    <div className={styles.Row}>
-      The current profile contains only Timeline data.
-    </div>
-  </div>
-);
-
 const tabs = [
   {
     id: 'flame-chart',
@@ -229,17 +191,6 @@ const tabs = [
     icon: 'ranked-chart',
     label: 'Ranked',
     title: 'Ranked chart',
-  },
-];
-
-const tabsWithTimeline = [
-  ...tabs,
-  null, // Divider/separator
-  {
-    id: 'timeline',
-    icon: 'timeline',
-    label: 'Timeline',
-    title: 'Timeline',
   },
 ];
 

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilerContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilerContext.js
@@ -29,7 +29,7 @@ import {useCommitFilteringAndNavigation} from './useCommitFilteringAndNavigation
 
 import type {CommitDataFrontend, ProfilingDataFrontend} from './types';
 
-export type TabID = 'flame-chart' | 'ranked-chart' | 'timeline';
+export type TabID = 'flame-chart' | 'ranked-chart';
 
 export type Context = {
   // Which tab is selected in the Profiler UI?
@@ -204,7 +204,7 @@ function ProfilerContextController({children}: Props): React.Node {
     }
   }
 
-  const [selectedTabID, selectTab] = useLocalStorage<TabID>(
+  const [persistedTabID, selectTab] = useLocalStorage<TabID>(
     'React::DevTools::Profiler::defaultTab',
     'flame-chart',
     value => {
@@ -216,6 +216,11 @@ function ProfilerContextController({children}: Props): React.Node {
       });
     },
   );
+
+  // The persisted value may name a tab that no longer exists,
+  // e.g. the removed "timeline" tab. Fall back rather than render nothing.
+  const selectedTabID: TabID =
+    persistedTabID === 'ranked-chart' ? persistedTabID : 'flame-chart';
 
   const stopProfiling = useCallback(
     () => store.profilerStore.stopProfiling(),

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilingImportExportButtons.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilingImportExportButtons.js
@@ -19,7 +19,6 @@ import {
   prepareProfilingDataFrontendFromExport,
 } from './utils';
 import {downloadFile} from '../utils';
-import {TimelineContext} from 'react-devtools-timeline/src/TimelineContext';
 import isArray from 'shared/isArray';
 import hasOwnProperty from 'shared/hasOwnProperty';
 
@@ -29,7 +28,6 @@ import type {ProfilingDataExport} from './types';
 
 export default function ProfilingImportExportButtons(): React.Node {
   const {isProfiling, profilingData, rootID} = useContext(ProfilerContext);
-  const {setFile} = useContext(TimelineContext);
   const store = useContext(StoreContext);
   const {profilerStore} = store;
 
@@ -76,6 +74,22 @@ export default function ProfilingImportExportButtons(): React.Node {
     }
   }, []);
 
+  const showImportError = (message: string | null) => {
+    modalDialogDispatch({
+      id: 'ProfilingImportExportButtons',
+      type: 'SHOW',
+      title: 'Import failed',
+      content: (
+        <Fragment>
+          <div>The profiling data you selected cannot be imported.</div>
+          {message !== null && (
+            <div className={styles.ErrorMessage}>{message}</div>
+          )}
+        </Fragment>
+      ),
+    });
+  };
+
   // TODO (profiling) We should probably use a transition for this and suspend while loading the file.
   // Local files load so fast it's probably not very noticeable though.
   const handleChange = () => {
@@ -87,39 +101,28 @@ export default function ProfilingImportExportButtons(): React.Node {
       const fileReader = new FileReader();
       fileReader.addEventListener('load', () => {
         const raw = fileReader.result as any as string;
-        const json = JSON.parse(raw);
 
-        if (!isArray(json) && hasOwnProperty.call(json, 'version')) {
-          // This looks like React profiling data.
-          // But first, clear any User Timing marks; we should only have one type open at a time.
-          setFile(null);
+        let json;
+        try {
+          json = JSON.parse(raw);
+        } catch (error) {
+          showImportError(error !== null ? error.message : null);
+          return;
+        }
 
-          try {
-            const profilingDataExport = json as any as ProfilingDataExport;
-            profilerStore.profilingData =
-              prepareProfilingDataFrontendFromExport(profilingDataExport);
-          } catch (error) {
-            modalDialogDispatch({
-              id: 'ProfilingImportExportButtons',
-              type: 'SHOW',
-              title: 'Import failed',
-              content: (
-                <Fragment>
-                  <div>The profiling data you selected cannot be imported.</div>
-                  {error !== null && (
-                    <div className={styles.ErrorMessage}>{error.message}</div>
-                  )}
-                </Fragment>
-              ),
-            });
-          }
-        } else {
-          // Otherwise let's assume this is Trace Event data and pass it to the Timeline preprocessor.
-          // But first, clear React profiling data; we should only have one type open at a time.
-          profilerStore.clear();
+        if (isArray(json) || !hasOwnProperty.call(json, 'version')) {
+          showImportError(
+            'This file does not look like a profile exported from the React DevTools profiler.',
+          );
+          return;
+        }
 
-          // TODO (timeline) We shouldn't need to re-open the File but we'll need to refactor to avoid this.
-          setFile(file);
+        try {
+          const profilingDataExport = json as any as ProfilingDataExport;
+          profilerStore.profilingData =
+            prepareProfilingDataFrontendFromExport(profilingDataExport);
+        } catch (error) {
+          showImportError(error !== null ? error.message : null);
         }
       });
       fileReader.readAsText(file);


### PR DESCRIPTION
Cleaning up the Timeline profiler in the next commit on top of this one.

If user is debugging React 19.2+, we will show a suggestion to record a trace on Performance panel. Otherwise, we will suggest to upgrade to React 19.2 to unlock Performance tracks.

<img width="751" height="832" alt="Screenshot 2026-08-03 at 14 57 43" src="https://github.com/user-attachments/assets/153e712b-8f7c-4ec5-87f8-b01cf1180aae" />